### PR TITLE
remove num channels and freq range checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ services:
 | Variable | Description | Required | Default |
 |----------|-------------|---------|--------|
 | `TZ` | Your timezone | No | UTC |
-| `SERIAL` | The serial number of your RTL-SDR dongle | Yes | Blank |
+| `SERIAL` | The serial number of your RTL-SDR dongle. Exactly one of `SERIAL` and `SOAPYSDR` shoudl be set. | No | Blank |
+| `SOAPYSDR` | The SoapySDR device string that identifies your dongle. Currently only the SoapyRTLTCP driver is included. Exactly one of `SERIAL` and `SOAPYSDR` shoudl be set. | No | Blank |
 | `FEED_ID` | Used by the decoder to insert a unique ID in to the output message | Yes | Blank |
 | `FREQUENCIES` | Colon-separated list of frequencies, but to a maximum of 8, for the decoder to list to. No decimal, and all frequencies should be nine digits long. | Yes | Blank |
 | `PPM` | Parts per million correction of the decoder | No | 0 |

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ services:
 | Variable | Description | Required | Default |
 |----------|-------------|---------|--------|
 | `TZ` | Your timezone | No | UTC |
-| `SERIAL` | The serial number of your RTL-SDR dongle. Exactly one of `SERIAL` and `SOAPYSDR` shoudl be set. | No | Blank |
-| `SOAPYSDR` | The SoapySDR device string that identifies your dongle. Currently only the SoapyRTLTCP driver is included. Exactly one of `SERIAL` and `SOAPYSDR` shoudl be set. | No | Blank |
+| `SERIAL` | The serial number of your RTL-SDR dongle. Exactly one of `SERIAL` or `SOAPYSDR` should be set. | No | Blank |
+| `SOAPYSDR` | The SoapySDR device string that identifies your dongle. Currently only the SoapyRTLTCP driver is included. Exactly one of `SERIAL` or `SOAPYSDR` should be set. | No | Blank |
 | `FEED_ID` | Used by the decoder to insert a unique ID in to the output message | Yes | Blank |
 | `FREQUENCIES` | Colon-separated list of frequencies, but to a maximum of 8, for the decoder to list to. No decimal, and all frequencies should be nine digits long. | Yes | Blank |
 | `PPM` | Parts per million correction of the decoder | No | 0 |

--- a/rootfs/etc/cont-init.d/01-dumpvdl2
+++ b/rootfs/etc/cont-init.d/01-dumpvdl2
@@ -20,13 +20,6 @@ read -ra SPLIT_FREQS <<< "${FREQUENCIES}"
 
 # loop through SPLIT_FREQS
 
-# We can only have 8 total frequencies
-
-if [[ "${#SPLIT_FREQS[@]}" -gt 8 ]]; then
-	echo "FREQUENCIES may not contain more than 8 frequencies, exiting"
-	exit 1
-fi
-
 # FREQUENCIES needs to be in the range of 118000000 (118 MHz) - 137000000 (137 MHz).
 # Acceptable format is either in Hz (dumpvdl2 default) or in MHz (as with acarsdec)
 
@@ -35,8 +28,7 @@ for i in "${SPLIT_FREQS[@]}"
 do
 	[[ "$i" == *"."* ]] && j="${i/./}000" || j="$i" # convert xxx.xxx (MHz) into Hertz yyyyyy000 if needed
 	if [[ $(echo "$j > 118000000" | bc)  -eq 0 || $(echo "$j < 137000000" | bc) -eq 0 ]]; then
-		echo "FREQUENCY $i is not in the range of 118000000 - 137000000 or 118.0 - 137.0, exiting"
-		exit 1
+		echo "warning: FREQUENCY $i is not in the range of 118000000 - 137000000 or 118.0 - 137.0"
 	fi
 	FREQ_STRING+="$j "
 done


### PR DESCRIPTION
num channels check is redundant with dumpvdl2 check, which I have a PR in to remove anyway

frequency range check is unnecessarily limiting, there was some chat in the discord about potential signals above 137 MHz in a waterfall