### PR TITLE
optionally use librtlsdr directly without soapy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN set -x && \
     mkdir -p /src/dumpvdl2/build && \
     pushd /src/dumpvdl2/build && \
     # cmake ../ && \
-    cmake ../ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRTLSDR=FALSE && \
+    cmake ../ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRTLSDR=TRUE && \
     make -j "$(nproc)" && \
     make install && \
     popd && \

--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Please note: **DUE TO LIBSDRPLAY, THIS CONTAINER WILL NOT RUN ON ARM32 DEVICES**
 
 A computer host on a suitable architecture and one USB RTL-SDR dongle connected to an antenna.
 
-## Deprecation Notice
-
-`SERIAL` has been deprecated in favor of `SOAPYSDR`. Please update your configuration accordingly. If `SERIAL` is set the driver will be set to `rtlsdr` and the serial number will be set to the value of `SERIAL`.
-
 ## Up and running
 
 ```yaml
@@ -33,7 +29,7 @@ services:
     ports:
     environment:
       - TZ="America/Denver"
-      - SOAPYSDR=driver=rtlsdr,serial=13305
+      - RTL_SERIAL=13305
       - FEED_ID=VDLM
       - FREQUENCIES=136725000;136975000;136875000
       - ZMQ_MODE=server
@@ -52,6 +48,8 @@ services:
 | Variable             | Description                                                                                                                                                                                      | Required | Default                                                        |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | -------------------------------------------------------------- |
 | `TZ`                 | Your timezone                                                                                                                                                                                    | No       | UTC                                                            |
+| `RTL_SERIAL`         | The rtlsdr device serial that identifies your dongle.                                                                                                                                            | No       | Blank                                                          |
+| `BIASTEE`            | Enable biastee when using RTL_SERIAL (doesn't work with SOAPY).                                                                                                                                  | No       | Blank                                                          |
 | `SOAPYSDR`           | The SoapySDR device string that identifies your dongle. See below for supported soapy sdr types.                                                                                                 | No       | Blank                                                          |
 | `SOAPY_DEVICE_SETTINGS` | The SoapySDR settings string with comma separated options, example: biastee=true                                                                                                 | No       | Blank                                                          |
 | `FEED_ID`            | Used by the decoder to insert a unique ID in to the output message                                                                                                                               | Yes      | Blank                                                          |

--- a/rootfs/etc/s6-overlay/scripts/dumpvdl2
+++ b/rootfs/etc/s6-overlay/scripts/dumpvdl2
@@ -11,6 +11,10 @@ VDLM_BIN="/usr/local/bin/dumpvdl2"
 FREQ_STRING=""
 VDLM_CMD=()
 
+if [[ -z "${RTL_SERIAL}" ]] && [[ -n "${SERIAL}" ]]; then
+    # if RTL_SERIAL not set, use legacy env var SERIAL
+    RTL_SERIAL="${SERIAL}"
+fi
 
 # Specify device ID
 if [ -n "${SOAPYSDR}" ]; then
@@ -18,8 +22,13 @@ if [ -n "${SOAPYSDR}" ]; then
     if [[ -n "$SOAPY_DEVICE_SETTINGS" ]]; then
         VDLM_CMD+=("--device-settings" "$SOAPY_DEVICE_SETTINGS")
     fi
-elif [ -n "${SERIAL}" ]; then
-	VDLM_CMD+=("--soapysdr" "driver=rtlsdr,serial=$SERIAL")
+elif [[ -n "${RTL_SERIAL}" ]]; then
+	VDLM_CMD+=("--rtlsdr" "$RTL_SERIAL")
+    if chk_enabled "${BIASTEE}"; then
+        VDLM_CMD+=("--bias" "1")
+    else
+        VDLM_CMD+=("--bias" "0")
+    fi
 fi
 
 if [ -n "$CENTER_FREQ" ]; then


### PR DESCRIPTION
soapy can be problematic plus dumpvdl2 uses less CPU when using librtlsdr directly as it choose a lower sample rate for some reason