### PR TITLE
chore(flake/nixpkgs): `46db2e09` -> `6201e203`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`86cd6636`](https://github.com/NixOS/nixpkgs/commit/86cd6636957ca461cf86877409b9c87d366092ad) | `` python3Packages.pydantic-ai-slim: 1.73.0 -> 1.75.0 ``                                              |
| [`36efa952`](https://github.com/NixOS/nixpkgs/commit/36efa95274f673eff999737d12ba45118eac8648) | `` python3Packages.pydantic-graph: 1.73.0 -> 1.75.0 ``                                                |
| [`c9a4d6b8`](https://github.com/NixOS/nixpkgs/commit/c9a4d6b88f69ee96315d7cd2d33a5c174f4a195f) | `` maintainers: remove Golo300 ``                                                                     |
| [`972eb68b`](https://github.com/NixOS/nixpkgs/commit/972eb68b76b8ae615ba7c8749111c89d00a4c7f5) | `` lazyworktree: 1.44.0 -> 1.45.0 ``                                                                  |
| [`174d70bc`](https://github.com/NixOS/nixpkgs/commit/174d70bcc24fd87fd2f52ae5772b2a00efd8f0ff) | `` libretro.play: 0-unstable-2026-03-13 -> 0-unstable-2026-03-31 ``                                   |
| [`5b90cc94`](https://github.com/NixOS/nixpkgs/commit/5b90cc94278a7b472cab6375928dd77306e83a04) | `` home-assistant-custom-lovelace-modules.auto-entities: 2.0.0 -> 2.1.0 ``                            |
| [`33cf9d5d`](https://github.com/NixOS/nixpkgs/commit/33cf9d5df4d137a40c3ba661a2e84cbe6f7d120a) | `` steelix: 0-unstable-2026-03-19 -> 0-unstable-2026-03-29 ``                                         |
| [`351c5d23`](https://github.com/NixOS/nixpkgs/commit/351c5d235dc9bf780c1fa368376e8e5eeffb8699) | `` python3Packages.iamdata: 0.1.202603311 -> 0.1.202604011 ``                                         |
| [`f094d71c`](https://github.com/NixOS/nixpkgs/commit/f094d71cae8754ad87b39261818580cd50b1b571) | `` rattler-build: 0.61.0 -> 0.61.4 ``                                                                 |
| [`eb24d8f9`](https://github.com/NixOS/nixpkgs/commit/eb24d8f9f7da35472276bf41ec468fe61a2c0e11) | `` libretro.mesen: 0-unstable-2024-10-21 -> 0-unstable-2026-03-31 ``                                  |
| [`0997310b`](https://github.com/NixOS/nixpkgs/commit/0997310b3a37a30c66dfda6d352d67964f188dc1) | `` phpunit: 13.0.5 -> 13.0.6 ``                                                                       |
| [`045d2f2c`](https://github.com/NixOS/nixpkgs/commit/045d2f2c3cd1febcaa392b350d85299630afcad7) | `` home-assistant-custom-components.solax_modbus: 2026.03.3 -> 2026.03.4 ``                           |
| [`64ff3454`](https://github.com/NixOS/nixpkgs/commit/64ff3454c79290908a703de8d525282c0942a5ba) | `` home-assistant-custom-components.pirate-weather: 1.8.4 -> 1.8.7 ``                                 |
| [`94dce7ec`](https://github.com/NixOS/nixpkgs/commit/94dce7ecabc4dedcf2d337851494af5e2c43c189) | `` python3Packages.google-cloud-run: 0.15.0 -> 0.16.0 ``                                              |
| [`84dd51c6`](https://github.com/NixOS/nixpkgs/commit/84dd51c6afd381488ca3986e02a98cbf449027ac) | `` postgresqlPackages.pg_background: 1.8 -> 1.9.1 ``                                                  |
| [`a4c700c9`](https://github.com/NixOS/nixpkgs/commit/a4c700c932157c90436ace26e98fe2ba5cfe2578) | `` postgresqlPackages.pg_search: 0.22.2 -> 0.22.4 ``                                                  |
| [`f70cc8bc`](https://github.com/NixOS/nixpkgs/commit/f70cc8bcd77bf92e57950424025b69399f0b74fa) | `` fiddler-everywhere: 7.7.1 -> 7.7.2 ``                                                              |
| [`78e1243a`](https://github.com/NixOS/nixpkgs/commit/78e1243abeaa04114065f7b53262afdefdb32544) | `` wakatime-cli: 1.139.2 -> 2.0.8 ``                                                                  |
| [`a2a7567a`](https://github.com/NixOS/nixpkgs/commit/a2a7567aad22a84f945ec3b1401dd7cf5aac3430) | `` firefox-devedition-unwrapped: 148.0b15 -> 150.0b3 ``                                               |
| [`34e4d06a`](https://github.com/NixOS/nixpkgs/commit/34e4d06a509a526c113894005479625e73748d4e) | `` python3Packages.pyais: 2.20.0 -> 2.20.1 ``                                                         |
| [`021181a2`](https://github.com/NixOS/nixpkgs/commit/021181a21155335642bd3484f300ac0da14f4c42) | `` kiro: 0.11.63 -> 0.11.107 ``                                                                       |
| [`3b179773`](https://github.com/NixOS/nixpkgs/commit/3b1797739a9c59474b7fcc8fe09b83f6b94c2f6b) | `` luau: 0.712 -> 0.714 ``                                                                            |
| [`4bd492e8`](https://github.com/NixOS/nixpkgs/commit/4bd492e8f76f613b2a7efaa98f73b62356810745) | `` mpdris2-rs: 1.1.0 -> 1.1.1 ``                                                                      |
| [`ede3c0cc`](https://github.com/NixOS/nixpkgs/commit/ede3c0cc7b5cb55ef3c13cad204ca3cea128d140) | `` python3Packages.tensordict: 0.11.0 -> 0.12.0 ``                                                    |
| [`91481ecf`](https://github.com/NixOS/nixpkgs/commit/91481ecf4847f0ba1bc60650a4adada4abcaf9f8) | `` python3Packages.aioopenssl: fix tests ``                                                           |
| [`ca421165`](https://github.com/NixOS/nixpkgs/commit/ca421165527b909ed7a23fa1e1344e426292078b) | `` jellyfin{,-web}: 10.11.6 -> 10.11.7 ``                                                             |
| [`e3ee7a0e`](https://github.com/NixOS/nixpkgs/commit/e3ee7a0eb77d1837e5dc418b7c2f74db1edf3020) | `` inputplumber: 0.75.2 -> 0.76.0 ``                                                                  |
| [`a55a91dc`](https://github.com/NixOS/nixpkgs/commit/a55a91dc3a45010c60b64167142c1c77bf56e3f8) | `` flclash: add VZstless as maintainer ``                                                             |
| [`fe75bc90`](https://github.com/NixOS/nixpkgs/commit/fe75bc906801d635c80dbce0ae451fc16a471979) | `` openvswitch: 3.7.0 -> 3.7.1 ``                                                                     |
| [`a5f852a8`](https://github.com/NixOS/nixpkgs/commit/a5f852a88a6e3110314cde24c50f39fabdf9f7d3) | `` hyprshell: 4.9.4 -> 4.9.5 ``                                                                       |
| [`9edaf663`](https://github.com/NixOS/nixpkgs/commit/9edaf663f3ffa704c22e55559f406a6a1e7c3e9a) | `` librelane: 3.0.0 -> 3.0.1 ``                                                                       |
| [`ba7d1b65`](https://github.com/NixOS/nixpkgs/commit/ba7d1b65988e42427218ad4511405b322f8d51c5) | `` mame: 0.286 -> 0.287 ``                                                                            |
| [`26d1718c`](https://github.com/NixOS/nixpkgs/commit/26d1718cf7f9ad6fb2f7e95578be8f0f610efa6c) | `` google-chrome: 146.0.7680.164 -> 146.0.7680.177 ``                                                 |
| [`1b5d3d01`](https://github.com/NixOS/nixpkgs/commit/1b5d3d01f06ec043ec99553b1e9828dfbbdbab10) | `` python3Packages.scalene: 2.1.4 -> 2.2.1 ``                                                         |
| [`d15d04c7`](https://github.com/NixOS/nixpkgs/commit/d15d04c78ec0bb23e8e0d7698415555668f6d4dc) | `` super-slicer: pick patch to drop unused ilmbase dependency ``                                      |
| [`4b93e4aa`](https://github.com/NixOS/nixpkgs/commit/4b93e4aacf980a2d999b01d03a5bd5e0d29751de) | `` prusa-slicer: pick patch to drop unused ilmbase dependency ``                                      |
| [`5d22f435`](https://github.com/NixOS/nixpkgs/commit/5d22f4353623d601f9da279dff20a9777c17553e) | `` orca-slicer: pick patch to remove unused ilmbase dependency ``                                     |
| [`f67c55ef`](https://github.com/NixOS/nixpkgs/commit/f67c55ef607e557c3d31d73632e842750b74ef37) | `` bambu-studio: drop unused ilmbase dependency ``                                                    |
| [`00db9c93`](https://github.com/NixOS/nixpkgs/commit/00db9c93a1c65a639e2f7306deae422c6e5f35ed) | `` dwmblocks: fix build with gcc15 ``                                                                 |
| [`6234dd86`](https://github.com/NixOS/nixpkgs/commit/6234dd8699d88ec14fdffa2bcf614d08924c5faa) | `` chromium,chromedriver: 146.0.7680.164 -> 146.0.7680.177 ``                                         |
| [`a44614f0`](https://github.com/NixOS/nixpkgs/commit/a44614f0664dad545dec748707af106c05fd22aa) | `` darktable: drop unused ilmbase dependency ``                                                       |
| [`f3a756f8`](https://github.com/NixOS/nixpkgs/commit/f3a756f86b5d2d2a1c1e64ad3d9d185712274606) | `` color-transformation-language: drop unused ilmbase dependency ``                                   |
| [`aacfecb4`](https://github.com/NixOS/nixpkgs/commit/aacfecb4ec84530aa5661fe14fc04c0e6a9cc998) | `` art: drop unused ilmbase dependency ``                                                             |
| [`dcd7b141`](https://github.com/NixOS/nixpkgs/commit/dcd7b1411ba5bd79ae79b1d51584d6e9cd9f55b1) | `` libretro.gambatte: 0-unstable-2026-03-13 -> 0-unstable-2026-03-31 ``                               |
| [`11bda3b3`](https://github.com/NixOS/nixpkgs/commit/11bda3b3bd1b5287d46134bd1de9164da964c18e) | `` system-manager: fix test sandbox failure, add latest-nix test ``                                   |
| [`282f8587`](https://github.com/NixOS/nixpkgs/commit/282f8587a2a15a6b28e1e61c57ab344a074c1fab) | `` burn-central-cli: 0.4.0 -> 0.4.1 ``                                                                |
| [`a74135d9`](https://github.com/NixOS/nixpkgs/commit/a74135d9ff96404ee150397d6cd548cb1bbe47c9) | `` c3c: 0.7.10 -> 0.7.11 ``                                                                           |
| [`08782d93`](https://github.com/NixOS/nixpkgs/commit/08782d935c44568eeb2121307cf9af196ffa09a3) | `` krita: remove ilmbase dependency to unbreak build ``                                               |
| [`df046197`](https://github.com/NixOS/nixpkgs/commit/df04619776ac27f9388d6209d31e23ffbd856c81) | `` cog: 0.1.4 -> 0.1.5 ``                                                                             |
| [`fb1554b6`](https://github.com/NixOS/nixpkgs/commit/fb1554b6e5f91e62d62f6c69101aa300c468a0a6) | `` osu-lazer: 2026.305.0 -> 2026.401.0 ``                                                             |
| [`50cbebb0`](https://github.com/NixOS/nixpkgs/commit/50cbebb0bcf88724d846a19bfc3aaa5ae13a6f4d) | `` osu-lazer-bin: 2026-305.0 -> 2026.401.0 ``                                                         |
| [`e115d700`](https://github.com/NixOS/nixpkgs/commit/e115d700c4a7acefc7b4c60e23a3b52e98128e76) | `` ginkgo: add Go 1.26 compatibility patch ``                                                         |
| [`0ce286db`](https://github.com/NixOS/nixpkgs/commit/0ce286db5897c814adbebb8aed1ced38c4af6dae) | `` objfw: 1.3.2 -> 1.5.1 ``                                                                           |
| [`3b78082f`](https://github.com/NixOS/nixpkgs/commit/3b78082f9ce8647c4439f5f1c300eb4a007dcd61) | `` vimPlugins.conjure: unbreak require check hook ``                                                  |
| [`711b1065`](https://github.com/NixOS/nixpkgs/commit/711b106514eb2bcb27fd389f5c8967bcc2e8e22e) | `` gokey: 0.2.0 -> 0.2.1 ``                                                                           |
| [`d65016f5`](https://github.com/NixOS/nixpkgs/commit/d65016f5a492efbefb00d8f7dd834d6bbfbe1370) | `` rtorrent: make updateScript update both this package and libtorrent-rakshasa ``                    |
| [`9ee176be`](https://github.com/NixOS/nixpkgs/commit/9ee176bee238e793e9ebe756b790104947316d98) | `` libretro.swanstation: 0-unstable-2025-08-02 -> 0-unstable-2026-03-28 ``                            |
| [`4cf3224c`](https://github.com/NixOS/nixpkgs/commit/4cf3224cfa2c12053951a13bbc75a849f937502a) | `` vimPlugins.sg-nvim: skip 'sg.health' module in require check hook ``                               |
| [`5bd407c9`](https://github.com/NixOS/nixpkgs/commit/5bd407c9dfd2845eeb3c88d6863623c5779a5ce4) | `` iosevka-bin: 34.1.0 -> 34.3.0 ``                                                                   |
| [`d30a2c0b`](https://github.com/NixOS/nixpkgs/commit/d30a2c0bec225a917c3f1a7af487d4543eff50bd) | `` nix-scheduler-hook: 0.7.2 -> 0.7.3, use nix 2.34 ``                                                |
| [`5b1caf1b`](https://github.com/NixOS/nixpkgs/commit/5b1caf1b2f440f7fa3b9a4801b8f475a00f2bc1b) | `` vscode-extensions.dart-code.dart-code: 3.130.1 -> 3.132.0 ``                                       |
| [`92f6dbb0`](https://github.com/NixOS/nixpkgs/commit/92f6dbb0ac61387fd49835d58c7b55fa0bb5d900) | `` python3Packages.google-cloud-vision: 3.12.1 -> 3.13.0 ``                                           |
| [`81de6968`](https://github.com/NixOS/nixpkgs/commit/81de696839d78fab844151e67bf4357e45c675b7) | `` python3Packages.modal: init at 1.3.5 ``                                                            |
| [`884591ea`](https://github.com/NixOS/nixpkgs/commit/884591ea2fd8e0dc495e5ccee5b0a3cab3c05159) | `` python3Packages.types-certifi: init at 2021.10.8.3 ``                                              |
| [`146fb01d`](https://github.com/NixOS/nixpkgs/commit/146fb01d7d7791f9448f8375f8941da715a1ebd6) | `` python3Packages.synchronicity: init at 0.11.1 ``                                                   |
| [`031b2eca`](https://github.com/NixOS/nixpkgs/commit/031b2eca45c4c22c158df2fefeba253e1aaa8441) | `` codex: 0.116.0 -> 0.118.0 ``                                                                       |
| [`f6324438`](https://github.com/NixOS/nixpkgs/commit/f6324438e10c8258d4540e5f910dce38c6ea7940) | `` usql: 0.21.1 -> 0.21.4 ``                                                                          |
| [`563669b5`](https://github.com/NixOS/nixpkgs/commit/563669b575c7e77e38fbb58d70fa2843c7b3129e) | `` python3Packages.oasatelematics: 0.3 -> 0.4 ``                                                      |
| [`80062fdb`](https://github.com/NixOS/nixpkgs/commit/80062fdb50c7fb9876d5efa14ac993f61fe2a3af) | `` checkov: 3.2.511 -> 3.2.513 ``                                                                     |
| [`dc90fde2`](https://github.com/NixOS/nixpkgs/commit/dc90fde27be5b07facff492bc2c7dd9d31f9c744) | `` jetbrains.datagrip: 2025.3.5 -> 2026.1 ``                                                          |
| [`c85df05b`](https://github.com/NixOS/nixpkgs/commit/c85df05b2245458bd91548c376e5e3b3019d95ec) | `` river-classic: 0.3.14 -> 0.3.15 ``                                                                 |
| [`81403813`](https://github.com/NixOS/nixpkgs/commit/81403813f16a813024c03de1050021dfcc328893) | `` nordpass: Add pname and version ``                                                                 |
| [`33aa67ad`](https://github.com/NixOS/nixpkgs/commit/33aa67ad92558292587475983af4e4bab1756d2c) | `` webdav: 5.11.3 -> 5.11.4 ``                                                                        |
| [`016f21d4`](https://github.com/NixOS/nixpkgs/commit/016f21d4d9bcf9632c4c4923aa7000f35039230e) | `` libhx: 5.3 -> 5.4 ``                                                                               |
| [`53967c81`](https://github.com/NixOS/nixpkgs/commit/53967c81aff21f029f3796743a282fe58fe9bc39) | `` terraform-providers.hashicorp_tfe: 0.74.1 -> 0.76.0 ``                                             |
| [`a00ea92e`](https://github.com/NixOS/nixpkgs/commit/a00ea92e340bf07d12b7771b51e65dea2e0d415a) | `` python3Packages.mitogen: 0.3.44 -> 0.3.45 ``                                                       |
| [`23fcdca3`](https://github.com/NixOS/nixpkgs/commit/23fcdca31f03a2527a0bb40e84f7109c2f4e41fd) | `` terraform-providers.f5networks_bigip: 1.25.1 -> 1.26.0 ``                                          |
| [`9e68b653`](https://github.com/NixOS/nixpkgs/commit/9e68b65375401e7a0d9b02b3ca6c9756c2af5d91) | `` python3Packages.busylight-core: migrate to finalAttrs ``                                           |
| [`2905adf0`](https://github.com/NixOS/nixpkgs/commit/2905adf0111c574eeafc8dda64aa9d08ba094b98) | `` python3Packages.google-cloud-iam-logging: migrate to finalAttrs ``                                 |
| [`80282d4d`](https://github.com/NixOS/nixpkgs/commit/80282d4d96de0fe553192ba87c0926060cf5e8cc) | `` linuxPackages.xpadneo: 0.10 -> 0.10.1 ``                                                           |
| [`8aa691bf`](https://github.com/NixOS/nixpkgs/commit/8aa691bf3d12a4f02ab55fe5b4556c5222c1ab42) | `` pdf-cli: rename from lnreader ``                                                                   |
| [`c7b21a3f`](https://github.com/NixOS/nixpkgs/commit/c7b21a3ffd9288ff477cf73f865b0d420d7af6e2) | `` terraform-providers.sumologic_sumologic: 3.2.4 -> 3.2.5 ``                                         |
| [`e9b8f5cf`](https://github.com/NixOS/nixpkgs/commit/e9b8f5cf5e1af9b08876006148ee35352479976c) | `` python3Packages.cohere: 5.20.7 -> 5.21.1 ``                                                        |
| [`c7d7fbb8`](https://github.com/NixOS/nixpkgs/commit/c7d7fbb8e99c21492819f1bcd4460a09c80530eb) | `` lichess-bot: 2026.3.18.1 -> 2026.3.29.1 ``                                                         |
| [`911218a8`](https://github.com/NixOS/nixpkgs/commit/911218a83d9c0252958ff7aef2ff27656815b974) | `` python3Packages.fing-agent-api: 1.0.3 -> 1.1.0 ``                                                  |
| [`988dc3e3`](https://github.com/NixOS/nixpkgs/commit/988dc3e32423222c7327c81b32a02ed55f99038b) | `` python3Packages.aiontfy: 0.8.3 -> 0.8.4 ``                                                         |
| [`29f5dd49`](https://github.com/NixOS/nixpkgs/commit/29f5dd49915eef07f6a6a814359ba8f473d2c39f) | `` sequoia-git: Add myself to maintainers ``                                                          |
| [`f0da8c0e`](https://github.com/NixOS/nixpkgs/commit/f0da8c0e9d61146f2d33de53a9dde4f46c0c1b20) | `` python3Packages.google-cloud-workstations: 0.7.0 -> 0.8.0 ``                                       |
| [`626b4ccd`](https://github.com/NixOS/nixpkgs/commit/626b4ccda92763a47e6a00ed943507ed1e1d9b68) | `` sequoia-git: init at 0.5.0 ``                                                                      |
| [`53e50e03`](https://github.com/NixOS/nixpkgs/commit/53e50e0374b288910b43ff6fd997e74ce3b08dfd) | `` libretro.same_cdi: 0-unstable-2025-01-31 -> 0-unstable-2026-03-31 ``                               |
| [`46ebe8e4`](https://github.com/NixOS/nixpkgs/commit/46ebe8e4598ea99d65e9c532f6ede95772da35ba) | `` opencode{,-desktop}: 1.3.7 -> 1.3.10 ``                                                            |
| [`be5d62b4`](https://github.com/NixOS/nixpkgs/commit/be5d62b45781858769037ac4647ac17ce3214d88) | `` python3Packages.google-cloud-texttospeech: 2.34.0 -> 2.35.0 ``                                     |
| [`71ad7a38`](https://github.com/NixOS/nixpkgs/commit/71ad7a38f9e32e2035a613ecf6ff65982d5ebd3d) | `` home-assistant-custom-components.versatile_thermostat: 9.2.2 -> 9.3.1 ``                           |
| [`8daef7a2`](https://github.com/NixOS/nixpkgs/commit/8daef7a28a2dc05ff8c0dac4a9baccf7f876912e) | `` gitea-actions-runner: 0.3.0 -> 0.3.1 ``                                                            |
| [`ce16811f`](https://github.com/NixOS/nixpkgs/commit/ce16811f2687655ade4bee7d374f3a7323295696) | `` oniux: 0.9.0 -> 0.10.0 ``                                                                          |
| [`efb71688`](https://github.com/NixOS/nixpkgs/commit/efb71688a7b2121a79bbcf713790b82c026e1861) | `` claude-code-acp: add alias ``                                                                      |
| [`776656d7`](https://github.com/NixOS/nixpkgs/commit/776656d769a7eadf81a21f324698106269b871c1) | `` nuclei-templates: 10.4.0 -> 10.4.1 ``                                                              |
| [`86c8131d`](https://github.com/NixOS/nixpkgs/commit/86c8131dcc141377c63b607deece4501e6661578) | `` libretro.o2em: 0-unstable-2024-10-21 -> 0-unstable-2026-03-31 ``                                   |
| [`835922a4`](https://github.com/NixOS/nixpkgs/commit/835922a4fb357d6455f4f089fdba890eff554a67) | `` fcitx5-array: init at 0.9.6 ``                                                                     |
| [`327bbfbc`](https://github.com/NixOS/nixpkgs/commit/327bbfbcf4cf6e15b53942af096ea1f6ab93fe5d) | `` python3Packages.dvc: 3.67.0 -> 3.67.1 ``                                                           |
| [`1ad4b6bf`](https://github.com/NixOS/nixpkgs/commit/1ad4b6bfc436063a842fdabe6cc3370ebc43f7cb) | `` xremap: 0.14.18 -> 0.14.19 ``                                                                      |
| [`3c2cf57a`](https://github.com/NixOS/nixpkgs/commit/3c2cf57a781d8d47b55e28311e27225acf5ac6cc) | `` luaPackages: update on 2026-03-31 ``                                                               |
| [`e7f48bdf`](https://github.com/NixOS/nixpkgs/commit/e7f48bdf4ba283fcc07bba3b95b2aa55148728ed) | `` luarocks-nix: 0-unstable-2024-05-31 -> 3.13-unstable-2026-03-30 ``                                 |
| [`db28443b`](https://github.com/NixOS/nixpkgs/commit/db28443b882233e0fa261f06259daa36196171fd) | `` luaPackages: add .editorconfig for generated-packages.nix ``                                       |
| [`8209a848`](https://github.com/NixOS/nixpkgs/commit/8209a8480a25eefd2b6a034c7635379c5ef90779) | `` mycelium: 0.7.3 -> 0.7.5 ``                                                                        |
| [`30d34cbd`](https://github.com/NixOS/nixpkgs/commit/30d34cbd89cff79c65e9dbf065f250f43dbc84e6) | `` python3Packages.onnx-asr: 0.10.2 -> 0.11.0 ``                                                      |
| [`148c3c26`](https://github.com/NixOS/nixpkgs/commit/148c3c2649823f53fd1e2f059d0deacbf29c9beb) | `` river: 0.4.1 -> 0.4.2 ``                                                                           |
| [`280e85f6`](https://github.com/NixOS/nixpkgs/commit/280e85f66b01f624481c3429dd2b12d7f617c0d1) | `` check-jsonschema: 0.37.0 -> 0.37.1 ``                                                              |
| [`dcdc7e11`](https://github.com/NixOS/nixpkgs/commit/dcdc7e114913294f7699bc63bb5edc452851f2af) | `` libretro.genesis-plus-gx: 0-unstable-2026-03-06 -> 0-unstable-2026-03-31 ``                        |
| [`16c8bd80`](https://github.com/NixOS/nixpkgs/commit/16c8bd80278d16ec4b30ca7385016383d740db1f) | `` python3Packages.construct-classes: 0.2.2 -> 0.2.3 ``                                               |
| [`db05e94d`](https://github.com/NixOS/nixpkgs/commit/db05e94d2d9f7d4ee055314f343a93c0dedd4b5a) | `` cockpit: 357 -> 359 ``                                                                             |
| [`b34d7e55`](https://github.com/NixOS/nixpkgs/commit/b34d7e55d644178fb81cc232a1279e547fb93357) | `` python3Packages.pyoverkiz: 1.20.0 -> 1.20.1 ``                                                     |
| [`8c21506f`](https://github.com/NixOS/nixpkgs/commit/8c21506f2cae7cf8226516e5e018c235bbaca598) | `` fosrl-newt: 1.10.3 -> 1.10.4 ``                                                                    |
| [`d143493f`](https://github.com/NixOS/nixpkgs/commit/d143493f707fc7e82be7387a62549ac4b16c4e2c) | `` pyrefly: 0.57.1 -> 0.58.0 ``                                                                       |
| [`35fe00bf`](https://github.com/NixOS/nixpkgs/commit/35fe00bf43f9b20b44690f5d11ad0ba1df2b8fee) | `` awsebcli: 3.27 -> 3.27.1 ``                                                                        |
| [`a4701318`](https://github.com/NixOS/nixpkgs/commit/a4701318ff046026a7c1b0b3b0b3eb6f1a4d12f5) | `` python3Packages.google-cloud-translate: 3.24.0 -> 3.25.0 ``                                        |
| [`ae658e84`](https://github.com/NixOS/nixpkgs/commit/ae658e84b5fdf4e9cc685bcebeed417992f587ce) | `` python3Packages.pygls: 2.1.0 -> 2.1.1 ``                                                           |
| [`8bc58dce`](https://github.com/NixOS/nixpkgs/commit/8bc58dceaa231193d6dcd88ec16a2b1dff9cc19c) | `` vscode-extensions.astro-build.astro-vscode: 2.16.13 -> 2.16.14 ``                                  |
| [`95dcb3c8`](https://github.com/NixOS/nixpkgs/commit/95dcb3c8f3da614d4bc007c1d64045927108b07f) | `` balena-cli: pin to NodeJS 24 ``                                                                    |
| [`1856b722`](https://github.com/NixOS/nixpkgs/commit/1856b7222204358bcac9a729352cf10ba35e0ff1) | `` terraform-providers.hashicorp_google-beta: 7.24.0 -> 7.25.0 ``                                     |
| [`a6b7a2c6`](https://github.com/NixOS/nixpkgs/commit/a6b7a2c60103a0e06d2b40ed36b6765c188a81cb) | `` cargo-release: 1.1.1 -> 1.1.2 ``                                                                   |
| [`520f0cbb`](https://github.com/NixOS/nixpkgs/commit/520f0cbbc6ff1c0a8f0fdfa0b6f9426700cc8233) | `` snakefmt: 0.11.5 -> 1.0.0 ``                                                                       |
| [`db3fbe32`](https://github.com/NixOS/nixpkgs/commit/db3fbe32f27e81f782ce1edee1515a25b8957625) | `` vimPlugins.vivify-vim: init at 0-unstable-2025-08-08 ``                                            |
| [`378d8711`](https://github.com/NixOS/nixpkgs/commit/378d871195d00e6dc2ee8d03f74e7c2e403c41e8) | `` python3Packages.google-cloud-iam-logging: 1.6.0 -> 1.7.0 ``                                        |
| [`ca76f041`](https://github.com/NixOS/nixpkgs/commit/ca76f041b9b40a9f0daf328fb617ea392dca4187) | `` squid: 7.4 -> 7.5 ``                                                                               |
| [`9d58fea3`](https://github.com/NixOS/nixpkgs/commit/9d58fea37c467363745f16c72e5670e505d8b425) | `` python314Packages.boto3-stubs: 1.42.78 -> 1.42.79 ``                                               |
| [`b05bb032`](https://github.com/NixOS/nixpkgs/commit/b05bb03256264c33eac53445b7c950212a5544bf) | `` python3Packages.jupyterhub: 5.4.3 -> 5.4.4 ``                                                      |
| [`cfae18ee`](https://github.com/NixOS/nixpkgs/commit/cfae18ee1377f5820a32b2e44439fa932e8669d7) | `` python3Packages.mypy-boto3-sagemaker: 1.42.77 -> 1.42.79 ``                                        |
| [`d3c81f44`](https://github.com/NixOS/nixpkgs/commit/d3c81f4454e963149fd0aae260a728076456ab74) | `` python3Packages.mypy-boto3-s3: 1.42.67 -> 1.42.79 ``                                               |
| [`b1093d8f`](https://github.com/NixOS/nixpkgs/commit/b1093d8f0255fb760d666c18ce8b9aada47b3fb0) | `` python3Packages.mypy-boto3-opensearch: 1.42.73 -> 1.42.79 ``                                       |
| [`be9b3aa3`](https://github.com/NixOS/nixpkgs/commit/be9b3aa35ffef7161fb539db084606bdc8b0101c) | `` python3Packages.mypy-boto3-logs: 1.42.77 -> 1.42.79 ``                                             |
| [`4aaa7bbe`](https://github.com/NixOS/nixpkgs/commit/4aaa7bbe4c67172071e18f20e6242843b4edc4ab) | `` python3Packages.mypy-boto3-lakeformation: 1.42.45 -> 1.42.79 ``                                    |
| [`6543eb83`](https://github.com/NixOS/nixpkgs/commit/6543eb8303d8948d6cf7cf8d74ba39bb765e1434) | `` python3Packages.mypy-boto3-gamelift: 1.42.75 -> 1.42.79 ``                                         |
| [`eb65afea`](https://github.com/NixOS/nixpkgs/commit/eb65afeae96b96c119f5714d0480df6ce93b52e3) | `` python3Packages.mypy-boto3-ecs: 1.42.69 -> 1.42.79 ``                                              |
| [`1df36620`](https://github.com/NixOS/nixpkgs/commit/1df36620033a642fc74e4c736adfe5e07db7a46d) | `` python3Packages.mypy-boto3-autoscaling: 1.42.33 -> 1.42.79 ``                                      |
| [`401c9f14`](https://github.com/NixOS/nixpkgs/commit/401c9f14a0c9196fe16c299ee7b74f41fa9587b2) | `` python3Packages.mypy-boto3-appstream: 1.42.54 -> 1.42.79 ``                                        |
| [`2aa3f9ba`](https://github.com/NixOS/nixpkgs/commit/2aa3f9ba2202bb298629e4f2bb6c8604d13ded5f) | `` python3Packages.tencentcloud-sdk-python: 3.1.64 -> 3.1.67 ``                                       |
| [`8a268ad4`](https://github.com/NixOS/nixpkgs/commit/8a268ad44d1f20224e9c31bb6bf41497de9ff6f4) | `` linuxPackages.apfs: 0.3.16 -> 0.3.18 ``                                                            |
| [`b96544c6`](https://github.com/NixOS/nixpkgs/commit/b96544c64fd9d4367e676fbed9bf6c3af87f900b) | `` python3Packages.iamdata: 0.1.202603301 -> 0.1.202603311 ``                                         |
| [`604c7dae`](https://github.com/NixOS/nixpkgs/commit/604c7dae4824aafdec02eb5dbf43fae1fe69dc51) | `` python3Packages.freud: extend comment for disabledTests ``                                         |
| [`948e7e3c`](https://github.com/NixOS/nixpkgs/commit/948e7e3ceeb82cb736517ec77fadefdca791812e) | `` python3Packages.appium-python-client: 5.2.7 -> 5.3.0 ``                                            |
| [`d1b4642c`](https://github.com/NixOS/nixpkgs/commit/d1b4642ca1e5648ab3a73376ca2d161e64967459) | `` vscode-extensions.pkief.material-icon-theme: 5.32.0 -> 5.33.1 ``                                   |
| [`eca95bc2`](https://github.com/NixOS/nixpkgs/commit/eca95bc2ef14e8421a9ccb9c8da5c6f1e5cd8292) | `` python3Packages.freud: readd comment linking to #255262 ``                                         |
| [`6c59e1d6`](https://github.com/NixOS/nixpkgs/commit/6c59e1d6015fdef1cd0df279a0c98490123e4a14) | `` nest-cli: 11.0.16 -> 11.0.17 ``                                                                    |
| [`e13e1d96`](https://github.com/NixOS/nixpkgs/commit/e13e1d96e0a6ae10ec4faf74e40fbcaeb4d0c506) | `` beam26Packages.elvis-erlang: 4.2.3 -> 5.0.2 ``                                                     |
| [`fd6473bd`](https://github.com/NixOS/nixpkgs/commit/fd6473bdb16d810979646f3a77835aa532202b10) | `` lk-jwt-service: 0.4.1 -> 0.4.2 ``                                                                  |
| [`745672e4`](https://github.com/NixOS/nixpkgs/commit/745672e43c6c35397ad1f192699c62f2091a2588) | `` qalculate-gtk: 5.9.0 -> 5.10.0 ``                                                                  |
| [`cf661731`](https://github.com/NixOS/nixpkgs/commit/cf66173156bf33e4df773bafce3d0977e0f1efa1) | `` qalculate-qt: 5.9.0.1 -> 5.10.0 ``                                                                 |
| [`e6743f69`](https://github.com/NixOS/nixpkgs/commit/e6743f691817e5a78631ae28c4f3dec617509906) | `` libretro.beetle-wswan: 0-unstable-2024-10-21 -> 0-unstable-2026-03-31 ``                           |
| [`82ef82db`](https://github.com/NixOS/nixpkgs/commit/82ef82dbe652a0c75802fe88c40155d7acbe76c8) | `` libretro.nxengine: 0-unstable-2024-10-21 -> 0-unstable-2026-03-31 ``                               |
| [`faf4ca51`](https://github.com/NixOS/nixpkgs/commit/faf4ca51b2f7bf5a1827e45f88d1dac0c68d28ab) | `` helix-db: 2.1.3 -> 2.3.3 ``                                                                        |
| [`0d966335`](https://github.com/NixOS/nixpkgs/commit/0d966335015fe7341c7c76a76c158ae6962dd274) | `` python3Packages.scantree: init at 0.0.4 ``                                                         |
| [`44e15c7c`](https://github.com/NixOS/nixpkgs/commit/44e15c7c8aeea71c0dd58472e36cc2cf9a5e7bf4) | `` vscode-extensions.anthropic.claude-code: 2.1.87 -> 2.1.88 ``                                       |
| [`a3cbc923`](https://github.com/NixOS/nixpkgs/commit/a3cbc9234bdc51052b061e42ba7a8f75713199e9) | `` claude-code-bin: 2.1.87 -> 2.1.88 ``                                                               |
| [`ec81f6c2`](https://github.com/NixOS/nixpkgs/commit/ec81f6c246535bd5d995b11aaeaa8e8e305b00ef) | `` claude-code: 2.1.87 -> 2.1.88 ``                                                                   |
| [`f26aa73d`](https://github.com/NixOS/nixpkgs/commit/f26aa73d938f60203eeb706cfd1f8dab37de3dc4) | `` plasma-panel-spacer-extended: 1.13.0 -> 1.14.0 ``                                                  |
| [`ed976eee`](https://github.com/NixOS/nixpkgs/commit/ed976eeee216dea0b203a1c103b33329f27332de) | `` tree-sitter-grammars.tree-sitter-fsharp: 0.1.0-unstable-2025-07-05 -> 0.2.2-unstable-2026-03-29 `` |
| [`6d70fa0d`](https://github.com/NixOS/nixpkgs/commit/6d70fa0dceca3c0411796351ae62b2847addbb49) | `` tree-sitter-grammars.tree-sitter-vhdl: 1.3.1-unstable-2026-02-21 -> 1.4.0-unstable-2026-03-29 ``   |
| [`f26210b1`](https://github.com/NixOS/nixpkgs/commit/f26210b19cf440b325b9366a65876b4eed5e5f2d) | `` openfga: 1.12.1 -> 1.13.1 ``                                                                       |
| [`0917ae66`](https://github.com/NixOS/nixpkgs/commit/0917ae660bf2a3b864f03de3aab9d710d6599a6c) | `` libretro.mame2015: 0-unstable-2023-10-31 -> 0-unstable-2026-03-31 ``                               |
| [`b4640df6`](https://github.com/NixOS/nixpkgs/commit/b4640df6948e37ad4b41d8be245c5d497ec45265) | `` matlab-language-server: 1.1.6 -> 1.3.9 ``                                                          |
| [`e138819b`](https://github.com/NixOS/nixpkgs/commit/e138819b9deeeac87bbec462560468c6f4bec3c4) | `` libretro.fceumm: 0-unstable-2025-09-13 -> 0-unstable-2026-03-31 ``                                 |
| [`30e184cd`](https://github.com/NixOS/nixpkgs/commit/30e184cd60db866603309569f061facb067ee19f) | `` turingdb: 1.23 -> 1.26 ``                                                                          |
| [`63ab6717`](https://github.com/NixOS/nixpkgs/commit/63ab67171295d3276e4d67746f0f40c53ab7b944) | `` paratest: 7.19.2 -> 7.20.0 ``                                                                      |
| [`21a107af`](https://github.com/NixOS/nixpkgs/commit/21a107afa75619009ffc5f1f3ac6793992bd26a4) | `` tirith: 0.2.8 -> 0.2.10 ``                                                                         |
| [`960ea96c`](https://github.com/NixOS/nixpkgs/commit/960ea96c169143367b58f7d17255c92652a3abbe) | `` tscli: 0.1.0 -> 0.2.0 ``                                                                           |
| [`84414411`](https://github.com/NixOS/nixpkgs/commit/84414411b1a4d4f95d8d148b233a5434f4cc83bb) | `` terraform-providers.cloudposse_utils: 2.4.0 -> 2.5.0 ``                                            |
| [`28ff0c81`](https://github.com/NixOS/nixpkgs/commit/28ff0c81ff653b59fa27aa6002c7b6ccd8f4b902) | `` spotify-player: 0.22.1 -> 0.23.0 ``                                                                |
| [`fb352e63`](https://github.com/NixOS/nixpkgs/commit/fb352e63da110aaa61cb1e381f64c0348172681a) | `` rauc: 1.15.1 -> 1.15.2 ``                                                                          |
| [`225a45ac`](https://github.com/NixOS/nixpkgs/commit/225a45acf4204faf6082a6132ca0bca5bed7078a) | `` vscode-extensions.leanprover.lean4: 0.0.225 -> 0.0.226 ``                                          |
| [`20b6d30d`](https://github.com/NixOS/nixpkgs/commit/20b6d30d2c40be405fdf44c434f078f7818f4871) | `` python3Packages.foundrytools: init at 0.1.5 ``                                                     |
| [`c31d183b`](https://github.com/NixOS/nixpkgs/commit/c31d183b72e473493c36c1ef297ff5495e345095) | `` python3Packages.pycrashreport: 1.2.8 -> 2.0.0 ``                                                   |
| [`e1df3ce7`](https://github.com/NixOS/nixpkgs/commit/e1df3ce76bd07bb43ee5c1a92e620bf121b5d953) | `` nixos/tests/shelfmark: init ``                                                                     |
| [`3757b616`](https://github.com/NixOS/nixpkgs/commit/3757b61622b8087d7d17198c5ed012f697016e26) | `` nixos/shelfmark: init module ``                                                                    |
| [`a469aa29`](https://github.com/NixOS/nixpkgs/commit/a469aa29b0e2bb829ebdcf916a5e39294bb900be) | `` shelfmark: init at 1.2.0 ``                                                                        |
| [`7e5373f9`](https://github.com/NixOS/nixpkgs/commit/7e5373f9a7e0eeefb3586525855bc8b86ad82dcb) | `` agent-browser: init at 0.23.3 ``                                                                   |
| [`64d8b3d6`](https://github.com/NixOS/nixpkgs/commit/64d8b3d67ead1f8fc8a8b35fb99dc486ed30c2ce) | `` python3Packages.param: 2.3.1 -> 2.3.2 ``                                                           |
| [`85298750`](https://github.com/NixOS/nixpkgs/commit/852987500b8fb90e8a8c5956c87240c2e587888b) | `` nixosTests.mitmproxy: fix certificate location passed to curl ``                                   |
| [`f445e16b`](https://github.com/NixOS/nixpkgs/commit/f445e16b80184648504c86bb109683d42143426b) | `` cargo-insta: 1.47.1 -> 1.47.2 ``                                                                   |
| [`d0f631e3`](https://github.com/NixOS/nixpkgs/commit/d0f631e37b3979c245cbdb3b986ec92c88b4d42b) | `` python3Packages.ultralytics: 8.4.31 -> 8.4.32 ``                                                   |
| [`44a945e9`](https://github.com/NixOS/nixpkgs/commit/44a945e9af2a146c4a74b4d8e0e43591e49cfa4e) | `` python3Packages.busylight-core: 2.0.1 -> 2.2.0 ``                                                  |
| [`33b2d0d7`](https://github.com/NixOS/nixpkgs/commit/33b2d0d74dd4b3efa8ed0e5bf3aaec610884a550) | `` toml-sort: 0.24.3 -> 0.24.4 ``                                                                     |
| [`80d7a8f4`](https://github.com/NixOS/nixpkgs/commit/80d7a8f4b5cca9d163bee2786117d1e4dd030f99) | `` pay-respects: fix modules not building and strip api keys ``                                       |
| [`9c6f1cd4`](https://github.com/NixOS/nixpkgs/commit/9c6f1cd4c056e2e4071e5c408d059e590f2e351b) | `` mieru: 3.29.0 -> 3.30.0 ``                                                                         |
| [`eecf6714`](https://github.com/NixOS/nixpkgs/commit/eecf671490132b6dc1e9784329df25d4b3721226) | `` squashfsTools: fix build on darwin ``                                                              |
| [`faee5d6e`](https://github.com/NixOS/nixpkgs/commit/faee5d6e0f1975437267b1d81c4d4b0baa91a251) | `` meilisearch: 1.39.0 -> 1.41.0 ``                                                                   |
| [`47e8e428`](https://github.com/NixOS/nixpkgs/commit/47e8e428bf483336712da34f774f58e3573d4b85) | `` workflows/periodic-merge: replace commenting action with `gh` cli ``                               |
| [`978efcfc`](https://github.com/NixOS/nixpkgs/commit/978efcfca4c56f80cf9ad71ec157394a482fa1ba) | `` tlrc: 1.12.0 -> 1.13.0 ``                                                                          |
| [`00631322`](https://github.com/NixOS/nixpkgs/commit/00631322349715914db5b193b413706922282341) | `` telegraf: 1.38.1 -> 1.38.2 ``                                                                      |
| [`028ee253`](https://github.com/NixOS/nixpkgs/commit/028ee25368b533ffbdc2a0a9c03a2d488595c6ca) | `` gradle_9-unwrapped: 9.4.0 -> 9.4.1 ``                                                              |
| [`011756b6`](https://github.com/NixOS/nixpkgs/commit/011756b62f6b55c6558d7870e714315736946c00) | `` redumper: 705 -> 706 ``                                                                            |
| [`56fa9fe4`](https://github.com/NixOS/nixpkgs/commit/56fa9fe400bbdd70d82fec45e3382f93998a3c65) | `` vscode-extensions.sonarsource.sonarlint-vscode: 4.45.0 -> 5.0.0 ``                                 |
| [`b0d63a15`](https://github.com/NixOS/nixpkgs/commit/b0d63a15db9cead7b1cd08652a91642576d79db0) | `` python3Packages.tuya-device-handlers: 0.0.10 -> 0.0.16 ``                                          |
| [`e99e69d3`](https://github.com/NixOS/nixpkgs/commit/e99e69d3f55d72fd38f06b5805b4f3def36f0aa2) | `` sandbox-runtime: 0.0.43 -> 0.0.44 ``                                                               |
| [`cb09dde2`](https://github.com/NixOS/nixpkgs/commit/cb09dde2439d3a85cd600268ad3c7c9b89629825) | `` python3Packages.hyponcloud: 0.9.0 -> 0.9.1 ``                                                      |
| [`056c9a0b`](https://github.com/NixOS/nixpkgs/commit/056c9a0bc44f7544cf8a6c603f3eefe23079c3dd) | `` sing-box: 1.13.4 -> 1.13.5 ``                                                                      |
| [`bc14edfb`](https://github.com/NixOS/nixpkgs/commit/bc14edfb70d8e47aa1028b6eb5dcf50955d3dbe6) | `` mise: 2026.3.10 -> 2026.3.17 ``                                                                    |
| [`05ecbaa5`](https://github.com/NixOS/nixpkgs/commit/05ecbaa5d0c8e34a3b6b5dc94fab951cec7363d8) | `` chatterino2: 2.5.4 -> 2.5.5 ``                                                                     |
| [`09964178`](https://github.com/NixOS/nixpkgs/commit/099641782a909f6462d842ae0a89b5945d363eee) | `` honeycomb-refinery: 3.1.1 -> 3.1.2 ``                                                              |
| [`b5c40c9b`](https://github.com/NixOS/nixpkgs/commit/b5c40c9b5f6cea7338cee571b53782a5eb8997f5) | `` wlroots_0_20: fix dupe lcms2 dependency ``                                                         |
| [`9dbf4aa8`](https://github.com/NixOS/nixpkgs/commit/9dbf4aa82b1c15b2f172f9148ac38ccf5ac4fba9) | `` pscale: 0.276.0 -> 0.277.0 ``                                                                      |
| [`7e066f7a`](https://github.com/NixOS/nixpkgs/commit/7e066f7a1041c6f6cc22280f8e6597201f0a1e9e) | `` python3Packages.qh3: 1.7.0 -> 1.7.1 ``                                                             |
| [`f1b7b10d`](https://github.com/NixOS/nixpkgs/commit/f1b7b10d29087036f27b530011cccbfa8914bd75) | `` python3Packages.lmstudio: 1.5.0 -> 1.6.0b1 ``                                                      |
| [`dd1a5e24`](https://github.com/NixOS/nixpkgs/commit/dd1a5e245dc2919ee580fea01c017f54630cfccf) | `` thruster: 0.1.19 -> 0.1.20 ``                                                                      |
| [`18bee823`](https://github.com/NixOS/nixpkgs/commit/18bee823a48b0dca1de7576b3c47e04cfb3be04b) | `` phpstorm: 2025.3.4 -> 2026.1 ``                                                                    |
| [`a489471b`](https://github.com/NixOS/nixpkgs/commit/a489471b6f6c6d78983550f20d90e0268d86b934) | `` msedgedriver: rewrite and remove architectures that do not have matching edge versions ``          |
| [`31cbe253`](https://github.com/NixOS/nixpkgs/commit/31cbe253e9aac37db23808132114b625908b2db0) | `` luarocks-packages.csv: fix unsupported comment ``                                                  |
| [`93564f18`](https://github.com/NixOS/nixpkgs/commit/93564f18f8439a0fa230725863323bb17a6c6214) | `` euphonica: 0.99.1-beta -> 0.99.2-beta ``                                                           |
| [`00e68a9d`](https://github.com/NixOS/nixpkgs/commit/00e68a9d9e71988d344113a5ce44244515e9409e) | `` microsoft-edge: change update-script to also bump the edgedriver ``                                |
| [`70f3ec73`](https://github.com/NixOS/nixpkgs/commit/70f3ec73da7d06caba72aee3bd5640305faf4f8c) | `` python3Packages.ggml-python: remove useless args ``                                                |
| [`9e216330`](https://github.com/NixOS/nixpkgs/commit/9e216330ccd5e724b33931fa6fa00fb547b683ba) | `` python3Packages.pytorch-lightning: add GaetanLepage to maintainers ``                              |
| [`1651c44d`](https://github.com/NixOS/nixpkgs/commit/1651c44d9e711e7ec8c055c3495670c978424fa0) | `` python3Packages.pytorch-lightning: 2.6.1 -> 2.6.2 ``                                               |
| [`d22db82c`](https://github.com/NixOS/nixpkgs/commit/d22db82c1ee491f2b436fce3f464933129eae70a) | `` python3Packages.torch-bin: fix tests evaluation ``                                                 |
| [`dabae94b`](https://github.com/NixOS/nixpkgs/commit/dabae94bd3f900f9e582dd56e631e96dab989280) | `` python3Packages.eth-utils: 5.3.1 -> 6.0.0 ``                                                       |
| [`ed99d76e`](https://github.com/NixOS/nixpkgs/commit/ed99d76eadbcc6f7bf1f51e2458c25777179adb3) | `` wayshot: 1.4.5 -> 1.4.6 ``                                                                         |
| [`f04e9e47`](https://github.com/NixOS/nixpkgs/commit/f04e9e47e99c22734a0bbe4bb0be4efaf11b6a84) | `` b3sum: 1.8.3 -> 1.8.4 ``                                                                           |
| [`8d20b5c5`](https://github.com/NixOS/nixpkgs/commit/8d20b5c5d5b13610bf779dc7a0a0e1dad13c35b7) | `` actionlint: 1.7.11 -> 1.7.12 ``                                                                    |
| [`839fcd07`](https://github.com/NixOS/nixpkgs/commit/839fcd0704e11c3609ce2dd77c699825d74186c3) | `` arrpc: 3.6.0 -> 3.7.0 ``                                                                           |
| [`a249e403`](https://github.com/NixOS/nixpkgs/commit/a249e403984ad2b99f49ec4321e5de2371e80b6a) | `` circleci-cli: 0.1.34770 -> 0.1.34950 ``                                                            |
| [`134fc2b7`](https://github.com/NixOS/nixpkgs/commit/134fc2b7ad1d6c3ce134e1bde498a2e20c4bbb0a) | `` deadbranch: 0.3.0 -> 0.4.0 ``                                                                      |
| [`6ff39583`](https://github.com/NixOS/nixpkgs/commit/6ff39583d67caa013371b260278edf64b9273f3e) | `` phel: 0.29.0 -> 0.30.0 ``                                                                          |
| [`5c2f3aad`](https://github.com/NixOS/nixpkgs/commit/5c2f3aad94b6d57f23035b5d8fb857e99e579fec) | `` ft2-clone: 2.12 -> 2.13 ``                                                                         |
| [`1d100db9`](https://github.com/NixOS/nixpkgs/commit/1d100db921bd4d75be7469554920e7da3e3273eb) | `` installFontsHook: install `psfu` fonts ``                                                          |
| [`80c801f8`](https://github.com/NixOS/nixpkgs/commit/80c801f80345104fc930d465fe8580afc5f47599) | `` ggml: 0.9.8 -> 0.9.9 ``                                                                            |
| [`e1aaee8a`](https://github.com/NixOS/nixpkgs/commit/e1aaee8a535e8c7878507aaa65cd9241f9611e26) | `` nixos/nominatim: add nominatim-api to PYTHONPATH ``                                                |
| [`6139e121`](https://github.com/NixOS/nixpkgs/commit/6139e121200781ba0351fc799cc406e282f012af) | `` gajim: 2.4.4 → 2.4.5 ``                                                                            |
| [`20abda14`](https://github.com/NixOS/nixpkgs/commit/20abda145916d37b2f4357201ea3c04699a9b0fb) | `` greenmask: 0.2.17 -> 0.2.18 ``                                                                     |
| [`5d0e2182`](https://github.com/NixOS/nixpkgs/commit/5d0e218226593f371469cbde62f5f8eabc875f19) | `` gajim: add vbgl as maintainer ``                                                                   |
| [`281af84a`](https://github.com/NixOS/nixpkgs/commit/281af84a012d1b88d7f325a7ef1cc1869c21a3f1) | `` owi: 0.2-unstable-2026-01-29 -> 0.2-unstable-2026-03-16 ``                                         |
| [`a8dd9729`](https://github.com/NixOS/nixpkgs/commit/a8dd972981c58e5c7f1b015bd670bb76a1fbf223) | `` maintainers/github-teams.json: Automated sync ``                                                   |
| [`674faa5f`](https://github.com/NixOS/nixpkgs/commit/674faa5faac7926a3c60ce7936e4b556f67e3f26) | `` lightwalletd: 0.4.18 -> 0.4.19 ``                                                                  |
| [`e5d6a6c3`](https://github.com/NixOS/nixpkgs/commit/e5d6a6c33b80368165d74621ecf9fa532cc5da2a) | `` ollama: 0.18.2 -> 0.19.0 ``                                                                        |
| [`ae298616`](https://github.com/NixOS/nixpkgs/commit/ae298616dbee6a532ee3086e47410f390f88a568) | `` prosody: bump community modules to ce716e5e0fee ``                                                 |
| [`b46f4901`](https://github.com/NixOS/nixpkgs/commit/b46f49011cc1e1c3c54fe7f18da9dcdee3a8ed83) | `` rke: 1.8.12 -> 1.8.13 ``                                                                           |
| [`de41b9c7`](https://github.com/NixOS/nixpkgs/commit/de41b9c7be02e05ecbe787894e4a0232a590b6ab) | `` rustypaste-cli: 0.9.4 -> 0.9.5 ``                                                                  |
| [`5acc9572`](https://github.com/NixOS/nixpkgs/commit/5acc9572d1da1c6d6d888d2118cd32153393cd3f) | `` elephant: 2.20.2 -> 2.20.3 ``                                                                      |
| [`b84fba12`](https://github.com/NixOS/nixpkgs/commit/b84fba128b85d8f8f157f272ad448b095329d34f) | `` trillian: 1.7.2 -> 1.7.3 ``                                                                        |
| [`16b7f4fc`](https://github.com/NixOS/nixpkgs/commit/16b7f4fcc0e1c4554496ea1f7033283932fc1804) | `` vault-ssh-plus: 0.7.8 -> 0.7.9 ``                                                                  |
| [`71a4254a`](https://github.com/NixOS/nixpkgs/commit/71a4254a018b014c0f4c3b35f30c7b6ef57f7dc5) | `` maintainers: Remove amesgen ``                                                                     |
| [`ef7eb326`](https://github.com/NixOS/nixpkgs/commit/ef7eb32648aa1aff018aa3dd1611c4e28b5582a8) | `` treewide: Remove amesgen from maintainers, take over some ``                                       |
| [`b31db129`](https://github.com/NixOS/nixpkgs/commit/b31db12977dea83a207b63d0dbbb05971ac591b4) | `` python3Packages.pymc: 5.28.2 -> 5.28.3 ``                                                          |
| [`5dfbe3ff`](https://github.com/NixOS/nixpkgs/commit/5dfbe3ff1f97ed76faaa32d8fd11a01b0148a363) | `` libdeltachat: 2.47.0 -> 2.48.0 ``                                                                  |
| [`d73d2bd7`](https://github.com/NixOS/nixpkgs/commit/d73d2bd74e9becc162007be90be5ecbadb5b8621) | `` python3Packages.mcstatus: 12.2.1 -> 13.0.1 ``                                                      |
| [`d3db669c`](https://github.com/NixOS/nixpkgs/commit/d3db669c3346170281e65c69e0dfbf1404db637e) | `` cargo-insta: 1.47.0 -> 1.47.1 ``                                                                   |
| [`eb09ede1`](https://github.com/NixOS/nixpkgs/commit/eb09ede136f95a5fd7434248510ac0584d1fc97e) | `` homebridge: 1.11.3 -> 1.11.4 ``                                                                    |
| [`adf2ec46`](https://github.com/NixOS/nixpkgs/commit/adf2ec46c7a1317d69e489dfcbb76a690370ee84) | `` python3Packages.gpiod: rename from libgpiod ``                                                     |
| [`2ac41218`](https://github.com/NixOS/nixpkgs/commit/2ac412186fa8ec6374eb12957334a2a679354e49) | `` cherry-studio: 1.7.9 -> 1.8.4 ``                                                                   |
| [`890adbe0`](https://github.com/NixOS/nixpkgs/commit/890adbe04d932e4c3caa4d167638ac82dbfd9092) | `` tinygo: use fixed go version ``                                                                    |
| [`4007f7c8`](https://github.com/NixOS/nixpkgs/commit/4007f7c86114428e7a1d738cbbe33965553e7145) | `` rep-grep: 0-unstable-2024-02-06 -> 0.0.8 ``                                                        |
| [`6637cb8e`](https://github.com/NixOS/nixpkgs/commit/6637cb8e5a3b9ce7c145112f8a528c35805fe26a) | `` python3Packages.pydrawise: 2025.9.0 -> 2026.3.0 ``                                                 |
| [`541f88cb`](https://github.com/NixOS/nixpkgs/commit/541f88cb717d7b1915e83ba0f6e949cc43542063) | `` python3Packages.habiticalib: 0.4.6 -> 0.4.7 ``                                                     |
| [`fad8c4bf`](https://github.com/NixOS/nixpkgs/commit/fad8c4bfd75dbc484b3078d7e077f09474bb1d69) | `` ren-find: 0-unstable-2024-01-11 -> 0.0.4 ``                                                        |
| [`f7402854`](https://github.com/NixOS/nixpkgs/commit/f7402854717e287d2405933d7a3d478d9f9ba4e9) | `` libkrun: 1.17.0 -> 1.17.4 ``                                                                       |
| [`991a1a8c`](https://github.com/NixOS/nixpkgs/commit/991a1a8cb7edf8056c3e292080063ab43dd5fd48) | `` perplexity-mcp: 0-unstable-2026-03-20 -> 0-unstable-2026-03-23 ``                                  |
| [`6ab57d62`](https://github.com/NixOS/nixpkgs/commit/6ab57d621e61f64fa2c863af3078f7ab4f086be5) | `` aegis-rs: init at 0.5.0 ``                                                                         |
| [`2ad52c4f`](https://github.com/NixOS/nixpkgs/commit/2ad52c4f14172f98b077fb4a10c5554d176eef93) | `` cockpit-podman: 122 -> 124 ``                                                                      |
| [`c3d9c16d`](https://github.com/NixOS/nixpkgs/commit/c3d9c16d0522c307c5a49918cf6276dbf30b6c63) | `` cockpit-files: 37 -> 39 ``                                                                         |
| [`83ccb95b`](https://github.com/NixOS/nixpkgs/commit/83ccb95b820179a891ac11e6c40672231cb97e4f) | `` cockpit-machines: 349.1 -> 351 ``                                                                  |
| [`4d8bc18f`](https://github.com/NixOS/nixpkgs/commit/4d8bc18f05ee10d0832bdfc11272c35bf6a19af9) | `` python3Packages.iamdata: 0.1.202603281 -> 0.1.202603301 ``                                         |
| [`5dcf2249`](https://github.com/NixOS/nixpkgs/commit/5dcf2249ad7c6ca80b2fc3e8c35b62cfc6609e48) | `` maintainers: add Granddave ``                                                                      |
| [`6bff8074`](https://github.com/NixOS/nixpkgs/commit/6bff80746993f8806faa96a5226103f7f6c01733) | `` listenbrainz-mpd: 2.3.9 -> 2.5.1 ``                                                                |
| [`eb04b1bc`](https://github.com/NixOS/nixpkgs/commit/eb04b1bcbdbf7907f42d3880ac79588a77811d6c) | `` python2Packages.wcwidth: typo ``                                                                   |
| [`c56295d5`](https://github.com/NixOS/nixpkgs/commit/c56295d5524609b7ccd20fe5fa69e55d0d7bb738) | `` beamPackages.expert: 0.1.0-rc.6 -> 0.1.0 ``                                                        |
| [`1539da8e`](https://github.com/NixOS/nixpkgs/commit/1539da8e5a06ad26a47e44adb6129b63a382aad1) | `` crowdsec: 1.7.6 -> 1.7.7 ``                                                                        |
| [`15b9a7f5`](https://github.com/NixOS/nixpkgs/commit/15b9a7f5872cb6a7819b165f3d4789f11cfef13c) | `` opencode{,-desktop}: 1.3.2 -> 1.3.7 ``                                                             |
| [`cbda4e87`](https://github.com/NixOS/nixpkgs/commit/cbda4e872410bcef6c2ff63767915d4f2f9df0bc) | `` python3Packages.django_4: drop ``                                                                  |
| [`01f7659b`](https://github.com/NixOS/nixpkgs/commit/01f7659b32f53a037b6272efba8a11ed04b9d151) | `` go-ethereum: 1.17.1 -> 1.17.2 ``                                                                   |
| [`82839c1e`](https://github.com/NixOS/nixpkgs/commit/82839c1e61d4b29f143b0e6f91dd9da2971ec08a) | `` pretix.plugins.zugferd: 2.6.2 -> 2.6.3 ``                                                          |
| [`7c85ce9c`](https://github.com/NixOS/nixpkgs/commit/7c85ce9cb0e552b5fd15fd49a4202c142e1f3604) | `` exaile: 4.2.1 -> 4.2.2 ``                                                                          |
| [`944a98b6`](https://github.com/NixOS/nixpkgs/commit/944a98b671bd990a0372043e9c1f3260d477ec76) | `` pretix.plugins.worldlinedirect: 1.1.0 -> 1.1.1 ``                                                  |
| [`a0d3a034`](https://github.com/NixOS/nixpkgs/commit/a0d3a03422c08df86eddfe865b842694ed83e9ae) | `` pretix.plugins.payone: 1.4.1 -> 1.4.2 ``                                                           |
| [`23b60990`](https://github.com/NixOS/nixpkgs/commit/23b609909da6663093db9accdf5ebbf05a16b024) | `` pretix.plugins.passbook: 1.14.0 -> 1.14.1 ``                                                       |
| [`46fd1f01`](https://github.com/NixOS/nixpkgs/commit/46fd1f01f375c014f2224899d2f8ec87aa90e19d) | `` pretix.plugins.mollie: 2.5.2 -> 2.5.3 ``                                                           |
| [`3e509a3f`](https://github.com/NixOS/nixpkgs/commit/3e509a3fbad577500eacbac3e9b41df27e25fda7) | `` pretix: 2026.2.0 -> 2026.3.0 ``                                                                    |
| [`7c2637f9`](https://github.com/NixOS/nixpkgs/commit/7c2637f965d59b93c2054b954b2525c971beb07d) | `` libqalculate: 5.9.0 -> 5.10.0 ``                                                                   |
| [`8acda648`](https://github.com/NixOS/nixpkgs/commit/8acda648e3d127d05dd21e1e833382dcd0c975ae) | `` python3Packages.django-statici18n: 2.6.0 -> 2.7.1 ``                                               |
| [`52529f17`](https://github.com/NixOS/nixpkgs/commit/52529f17f8a0a8e7094cb4d62ecf162ca1d1c7a1) | `` luaPackages.lua-rtoml: 0.2 -> 0.3 ``                                                               |
| [`9a4da9a6`](https://github.com/NixOS/nixpkgs/commit/9a4da9a6c940047e86735870c52f9c6b858831e1) | `` openmpi: ensure that fortran .mod files are in dev output ``                                       |
| [`3a21356b`](https://github.com/NixOS/nixpkgs/commit/3a21356b6a9eff675d8c6140027dd9822ec281d1) | `` python3Packages.pydantic-ai-slim: 1.70.0 -> 1.73.0 ``                                              |
| [`f48f235a`](https://github.com/NixOS/nixpkgs/commit/f48f235a22e65e73788dbb84d5c790f8e9297a40) | `` python3Packages.pydantic-graph: 1.70.0 -> 1.73.0 ``                                                |
| [`b5e4eb83`](https://github.com/NixOS/nixpkgs/commit/b5e4eb8319e80e323008db992586562186795b30) | `` lomiri-qt6.lomiri-indicator-network: init at 1.2.0 ``                                              |
| [`061f89bb`](https://github.com/NixOS/nixpkgs/commit/061f89bb5fc0bae38c59b581456bbd2c8eb1b3b4) | `` lomiri-qt6.lomiri-url-dispatcher: init at 0.1.4 ``                                                 |
| [`4a456d97`](https://github.com/NixOS/nixpkgs/commit/4a456d9796ff06ce8bf72f2c68400fa913655750) | `` lomiri-qt6.biometryd: init at 0.4.0 ``                                                             |
| [`a0a61ccf`](https://github.com/NixOS/nixpkgs/commit/a0a61ccf8c2d5f51f5ea3b2dcbbb902a58e8fd51) | `` {lomiri,lomiri-qt6}.morph-browser: Flip VM tests to being Qt6-specific ``                          |
| [`5dee41c8`](https://github.com/NixOS/nixpkgs/commit/5dee41c88be93700d08881df1b342f65a1c94826) | `` nixosTests.lomiri.desktop-appinteractions: Adjust to re-enabled Morph ``                           |
| [`7f002233`](https://github.com/NixOS/nixpkgs/commit/7f002233edf4340f6a0a70342e96d6d9ee8471d2) | `` nixosTests.lomiri.desktop-basics: Re-enable Morph check ``                                         |
| [`8d4eb711`](https://github.com/NixOS/nixpkgs/commit/8d4eb711842a430feabacc1712c06950cf182929) | `` nixos/lomiri: Add Qt6 Morph Browser ``                                                             |
| [`6ed37bcd`](https://github.com/NixOS/nixpkgs/commit/6ed37bcdd3e4b2f86a9e4f7d39826eb97e4e677b) | `` nixosTests.morph-browser: Turn into attrset of Qt5 & Qt6 variant tests ``                          |
| [`beef8b9c`](https://github.com/NixOS/nixpkgs/commit/beef8b9c1d796ed5d81919fa21186e9e992269f1) | `` lomiri-qt6.morph-browser: init at 1.99.3 ``                                                        |
| [`d7c18078`](https://github.com/NixOS/nixpkgs/commit/d7c18078839048f2db10f0efb8d0d3e8bbeb4381) | `` lomiri-qt6.lomiri-content-hub: init at 2.2.2 ``                                                    |
| [`08dae344`](https://github.com/NixOS/nixpkgs/commit/08dae344a14b52e607c553e55dd487543b27cca6) | `` lomiri-qt6.lomiri-app-launch: init at 0.1.12 ``                                                    |
| [`858ef0c2`](https://github.com/NixOS/nixpkgs/commit/858ef0c2aec941b4a26f1f11e2638a1004b4960a) | `` lomiri-qt6.gsettings-qt: init at 1.1.1 ``                                                          |
| [`5c123a48`](https://github.com/NixOS/nixpkgs/commit/5c123a480dacaa833ae777b17f5d3fdcd1d5438a) | `` lomiri-qt6.lomiri-download-manager: init at 0.3.0 ``                                               |
| [`db3a44c5`](https://github.com/NixOS/nixpkgs/commit/db3a44c51fa22134a19f6b0735ddb9b752b2c980) | `` lomiri-qt6.lomiri-action-api: init at 1.2.1 ``                                                     |
| [`7ac36d72`](https://github.com/NixOS/nixpkgs/commit/7ac36d7200728c69dca55dc6d273edf1bb207ed6) | `` lomiri-qt6.lomiri-api: init at 0.3.0 ``                                                            |
| [`bb733fc0`](https://github.com/NixOS/nixpkgs/commit/bb733fc0ad9343eb6a4d2fa204c4e6d17fbb489d) | `` lomiri-qt6.lomiri-ui-extras: init at 0.8.0 ``                                                      |
| [`9e988b6c`](https://github.com/NixOS/nixpkgs/commit/9e988b6cf1d8977178bf0b18bfb3083d10e19148) | `` lomiri-qt6.lomiri-ui-toolkit: init at 1.3.5904 ``                                                  |
| [`3114c840`](https://github.com/NixOS/nixpkgs/commit/3114c8400248edc3b56c8ea9979688daff660c4a) | `` lomiri-qt6.lomiri-wallpapers: init at 20.04.0 ``                                                   |
| [`c26bb58f`](https://github.com/NixOS/nixpkgs/commit/c26bb58fe8ae3f03013ae4e75879cf67433c94e0) | `` lomiri-qt6.lomiri-sounds: init at 25.01 ``                                                         |
| [`a2155efc`](https://github.com/NixOS/nixpkgs/commit/a2155efca1e93d3297c598964369270fb57c5e05) | `` lomiri-qt6.suru-icon-theme: init at 2025.05.0 ``                                                   |
| [`1313995f`](https://github.com/NixOS/nixpkgs/commit/1313995f1cf0f40663d86d90969107bfc19f5329) | `` lomiri-qt6.lomiri-schemas: init at 0.1.10 ``                                                       |
| [`a3425454`](https://github.com/NixOS/nixpkgs/commit/a3425454edd5853733ea4bef670f3d4239dcd699) | `` lomiri-qt6.deviceinfo: init at 0.2.4 ``                                                            |
| [`ea83efa0`](https://github.com/NixOS/nixpkgs/commit/ea83efa04ea96dc3c7ee6c41cb3b389dfa3cc5cd) | `` qt6Packages.libqtdbusmock: init at 0.10.0 ``                                                       |
| [`2c6c5230`](https://github.com/NixOS/nixpkgs/commit/2c6c5230d5a1cc75ed7c077e3d7e5caf241807ab) | `` qt6Packages.libqtdbustest: init at 0.4.0 ``                                                        |
| [`061dd162`](https://github.com/NixOS/nixpkgs/commit/061dd162bd8cb9941c510c26603e566c95659b1e) | `` lomiri-qt6.cmake-extras: init at 1.9 ``                                                            |
| [`51d71a62`](https://github.com/NixOS/nixpkgs/commit/51d71a622f9dd0fcc471f49b31b2b181887d7cd8) | `` lomiri-qt6: init ``                                                                                |
| [`92953019`](https://github.com/NixOS/nixpkgs/commit/9295301922179f2527518e8ecfe609936e94a211) | `` lomiri.lomiri-ui-toolkit: 1.3.5903 -> 1.3.5904 ``                                                  |
| [`347dd1a6`](https://github.com/NixOS/nixpkgs/commit/347dd1a6123d4d7a2de9fab45bc803719a203f58) | `` python3Packages.griffelib: 2.0.1 -> 2.0.2 ``                                                       |
| [`30dafa9b`](https://github.com/NixOS/nixpkgs/commit/30dafa9b7f870336513f7d9167033bf9faf9be8e) | `` eksctl: 0.224.0 -> 0.225.0 ``                                                                      |
| [`42ffad04`](https://github.com/NixOS/nixpkgs/commit/42ffad04d6c499da4654675e61a0c01cc5fff9e0) | `` xbyak: 7.35.3 -> 7.35.4 ``                                                                         |
| [`fbb1a7f4`](https://github.com/NixOS/nixpkgs/commit/fbb1a7f4ce14b5d5ec91ca48e403b3b9641afcad) | `` pulldown-cmark: 0.13.2 -> 0.13.3 ``                                                                |
| [`00f91220`](https://github.com/NixOS/nixpkgs/commit/00f9122077f9e8adb1940aa6f8ee4156fecd46ca) | `` python3Packages.claude-agent-sdk: 0.1.50 -> 0.1.52 ``                                              |
| [`c82318fd`](https://github.com/NixOS/nixpkgs/commit/c82318fd2466bc69ca36b4016a5980d95c94cb8b) | `` cargo-binstall: 1.17.8 -> 1.17.9 ``                                                                |
| [`ba75e2d3`](https://github.com/NixOS/nixpkgs/commit/ba75e2d39eb6d4ff4abad3354fe1b7c0e2893d14) | `` stix-{otf,two}: use installFonts ``                                                                |
| [`d33f8692`](https://github.com/NixOS/nixpkgs/commit/d33f8692f848d7fb9cd96f86a4bd989bac96e45f) | `` tabularis: init at 0.9.12 ``                                                                       |
| [`629cc19f`](https://github.com/NixOS/nixpkgs/commit/629cc19f2384732d0b765ca11e89b103995c6225) | `` tiled: 1.12.0 -> 1.12.1 ``                                                                         |
| [`6946a1e0`](https://github.com/NixOS/nixpkgs/commit/6946a1e00ff0c9ee72fccd12b0a6c06c68e5db83) | `` mealie: use 'python3' input ``                                                                     |
| [`c682eb4b`](https://github.com/NixOS/nixpkgs/commit/c682eb4b53c94409f3e83bea5f0d3b98cfe79689) | `` mealie: unpin 'pyhumps' ``                                                                         |
| [`6d380de6`](https://github.com/NixOS/nixpkgs/commit/6d380de67b4422a9a1bb1780ff56eea6c12385de) | `` ci/OWNERS: add radicle fetchers ``                                                                 |
| [`6422f90c`](https://github.com/NixOS/nixpkgs/commit/6422f90ca9ba54a4e6be1439f117a050435ab40f) | `` nixos/tests/radicle-ci-broker: add radicle team as maintainer ``                                   |

*... and 1644 more commits (truncated)*