### PR TITLE
chore(flake/precommit): `cb27f0e8` -> `0fe4cc46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777597424,
-        "narHash": "sha256-2szcq71hbF+FK4XrJa+sERYVo5rQVjPmxWjTMedLIXM=",
+        "lastModified": 1780504325,
+        "narHash": "sha256-EU52VleXVEQrX/CxqdoeQdJNSoWd1yr+0uyCtNFddYg=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "cb27f0e8312a14e144978fac6963d55897aa6dea",
+        "rev": "0fe4cc46813614423b1cd54c9de1c74a448c7f3d",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1777519017,
-        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
+        "lastModified": 1780456895,
+        "narHash": "sha256-CvRZn3Ut0scqLJ1xwQFkZwKGVBUUNBPrFVXRTMZpbfU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
+        "rev": "7cc96a6a3fd6613cafd633250a3934483479b9a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                                                     |
| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`0fe4cc46`](https://github.com/fredsystems/pre-commit-checks/commit/0fe4cc46813614423b1cd54c9de1c74a448c7f3d) | `` chore(deps): lock file maintenance (#30) ``                              |
| [`fc1980b4`](https://github.com/fredsystems/pre-commit-checks/commit/fc1980b44b4313b2eab16c1a22f66d6277fbc9ef) | `` chore(deps): update actions/checkout action to v6.0.3 (#29) ``           |
| [`83b82ae0`](https://github.com/fredsystems/pre-commit-checks/commit/83b82ae044da4cdd48a28eb83876a456d930b6b1) | `` chore(deps): update actions/checkout digest to df4cb1c (#28) ``          |
| [`25fb3bf8`](https://github.com/fredsystems/pre-commit-checks/commit/25fb3bf809f873993ec3816091d86112b27cf6ba) | `` chore(deps): lock file maintenance (#27) ``                              |
| [`09383f5f`](https://github.com/fredsystems/pre-commit-checks/commit/09383f5f0dfd038af0614bede6ca3288c36b61c9) | `` chore(deps): update cachix/install-nix-action digest to 8aa0397 (#26) `` |