### PR TITLE
chore(flake/nixpkgs): `9ae611a4` -> `567a49d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`3695e88a`](https://github.com/NixOS/nixpkgs/commit/3695e88a819f93cc5bda9bcb33b58b79a91fb62d) | `` src-cli: add burmudar as maintainer ``                                                      |
| [`5bcf4386`](https://github.com/NixOS/nixpkgs/commit/5bcf4386d9c4c05b1d64a61c976e538c020c4002) | `` python3Packages.pysilero-vad: 3.3.0 -> 3.3.1 ``                                             |
| [`2b5d0829`](https://github.com/NixOS/nixpkgs/commit/2b5d08293b1f172640badf3c5397afcbfbf083c1) | `` koreader: 2025.10 -> 2026.03 ``                                                             |
| [`b9fb78fa`](https://github.com/NixOS/nixpkgs/commit/b9fb78fae740e61df5a50ccf8783e67eb4a407c3) | `` snouty: enable networking on darwin ``                                                      |
| [`cd9338cc`](https://github.com/NixOS/nixpkgs/commit/cd9338cc440661eccdf7bc9cde3fc49bd09aabec) | `` lnd: 0.20.1-beta -> 0.21.0-beta ``                                                          |
| [`f1ca5a99`](https://github.com/NixOS/nixpkgs/commit/f1ca5a992b8d18e8c36906319ca2ae1d270a8c58) | `` sandbox-runtime: 0.0.54 -> 0.0.55 ``                                                        |
| [`a4f189a7`](https://github.com/NixOS/nixpkgs/commit/a4f189a774e51df19fbddb6c93dc9ab68bcdd787) | `` lux-cli: 0.31.1 -> 0.32.0 ``                                                                |
| [`392f1151`](https://github.com/NixOS/nixpkgs/commit/392f1151c77c9e1e29a16a474efa96ff43c0f083) | `` installFonts: move to pkgs/by-name ``                                                       |
| [`7bcb3f25`](https://github.com/NixOS/nixpkgs/commit/7bcb3f25b5a9497140d8883a1711da25faf4ba5c) | `` lzbench: 2.2 -> 2.3 ``                                                                      |
| [`153f0427`](https://github.com/NixOS/nixpkgs/commit/153f042752073a3afaed61e5edbe120cdcfe454a) | `` typst: use finalAttrs.src.tag in meta.changelog ``                                          |
| [`4b600f08`](https://github.com/NixOS/nixpkgs/commit/4b600f083cbb8f08f73e1b6851c1609767675bae) | `` typst: enable __structuredAttrs ``                                                          |
| [`6dda9ee4`](https://github.com/NixOS/nixpkgs/commit/6dda9ee493309feeb28a48ccab46c58f084c27fe) | `` libdeltachat: 2.52.0 -> 2.53.0 ``                                                           |
| [`9729dc88`](https://github.com/NixOS/nixpkgs/commit/9729dc88e02944088a01817c902ec975084ef540) | `` stalwart-vandelay: 1.0.2 -> 1.0.3 ``                                                        |
| [`7ace88a5`](https://github.com/NixOS/nixpkgs/commit/7ace88a586e8d88264ee8cb4deb2d04826541525) | `` libkrun-efi: 1.18.0 -> 1.19.0 ``                                                            |
| [`daafbd9c`](https://github.com/NixOS/nixpkgs/commit/daafbd9ccbb29200181f158180e1e98cf477aca3) | `` python3Packages.sparsediffpy: 0.4.0 -> 0.5.1 ``                                             |
| [`918dda35`](https://github.com/NixOS/nixpkgs/commit/918dda354003cf348959a95d3447d9d8c166291c) | `` vscode-extensions.scalameta.metals: 1.66.0 -> 1.67.0 ``                                     |
| [`2b541e8a`](https://github.com/NixOS/nixpkgs/commit/2b541e8a58c403a96e1b238d947e36f0fd398e3d) | `` wasmer: add shell completions ``                                                            |
| [`82cc3b44`](https://github.com/NixOS/nixpkgs/commit/82cc3b4418a3f31edd69c3b93d43fbc8f365827f) | `` vimPlugins.fff-nvim: 0.9.3 -> 0.9.4 ``                                                      |
| [`edd4c9cb`](https://github.com/NixOS/nixpkgs/commit/edd4c9cb8c1eb1aab657d10670a7573b8358154e) | `` lychee: 0.24.1 -> 0.24.2 ``                                                                 |
| [`67936cc4`](https://github.com/NixOS/nixpkgs/commit/67936cc4f7415aca1d8dba832f08f3eac55c4920) | `` compsize: `__structuredAttrs`, `strictDeps`, `enableParallelBuilding` ``                    |
| [`0f05671f`](https://github.com/NixOS/nixpkgs/commit/0f05671f5e3671e1c4c76521137ce856a73f256b) | `` compsize: add `man` output ``                                                               |
| [`34e8e9fc`](https://github.com/NixOS/nixpkgs/commit/34e8e9fce77cdf90f54e6025ce17e0699999bce8) | `` compsize: 1.5 -> 1.5-unstable-2023-12-24 ``                                                 |
| [`ea7e6999`](https://github.com/NixOS/nixpkgs/commit/ea7e6999e8673d7c015df6c8d91c4f77033e1958) | `` reframe: 1.16.0 -> 1.17.0 ``                                                                |
| [`52e3dccd`](https://github.com/NixOS/nixpkgs/commit/52e3dccdb43ebef575460b67248ed17ceb81986e) | `` adrs: 0.7.4 -> 0.7.6 ``                                                                     |
| [`bec06a51`](https://github.com/NixOS/nixpkgs/commit/bec06a510f6260c2605ee02ef90aa4b311fef701) | `` clickhouse-backup: 2.7.1 -> 2.7.2 ``                                                        |
| [`d58d5d57`](https://github.com/NixOS/nixpkgs/commit/d58d5d573ef5499de2c0c0b8d317c78aed1e38c4) | `` typst: add faukah to maintainers ``                                                         |
| [`e9275611`](https://github.com/NixOS/nixpkgs/commit/e9275611efecde6ba48bf166e91ecbcc2b974313) | `` typst: 0.14.2 -> 0.15.0 ``                                                                  |
| [`07eabf2f`](https://github.com/NixOS/nixpkgs/commit/07eabf2ff0ade8abd4cda1e709de6217c6441108) | `` evcc: 0.309.0 -> 0.309.1 ``                                                                 |
| [`f666e54e`](https://github.com/NixOS/nixpkgs/commit/f666e54eb0991510127c4f74c575c4122e01f4d6) | `` cudaPackages.libnvshmem: default withNccl to nccl.meta.available ``                         |
| [`101034d2`](https://github.com/NixOS/nixpkgs/commit/101034d25e4a3e1e3c440be9f0252de4cd71adba) | `` hck: 0.11.5 -> 0.11.6 ``                                                                    |
| [`e3cbda57`](https://github.com/NixOS/nixpkgs/commit/e3cbda57060aa64f99404a2bb8ea317999bbf5b1) | `` gcc/ng: reference landed `find_a_program` commits instead of mailing list ``                |
| [`92f4b978`](https://github.com/NixOS/nixpkgs/commit/92f4b9783725d5f1612a7c18bfcbbdcce1dd0f2c) | `` wdt: 1.27.1612021-unstable-2026-02-26 -> 1.27.1612021-unstable-2026-06-09 ``                |
| [`8c6f5ae0`](https://github.com/NixOS/nixpkgs/commit/8c6f5ae0200f32cbdddebf344ddbb97425db20c3) | `` kubernetes-helmPlugins.helm-diff: 3.15.8 -> 3.15.9 ``                                       |
| [`660cbeed`](https://github.com/NixOS/nixpkgs/commit/660cbeed66ebeda368db43716eee7e13f75bafe2) | `` python3Packages.cartopy: 0.25.0 -> 0.25.0.post2 ``                                          |
| [`0fd69dc2`](https://github.com/NixOS/nixpkgs/commit/0fd69dc26c5423235f2e30ea94eded99cb38b8dc) | `` weblate: skip null packages in relaxDeps logic ``                                           |
| [`bd252246`](https://github.com/NixOS/nixpkgs/commit/bd252246151f74547af88ab1f2b24abce808ece0) | `` ayatana-indicator-display: 24.5.2 -> 26.6.0 ``                                              |
| [`1d34faef`](https://github.com/NixOS/nixpkgs/commit/1d34faef06041c4cef80917a6c2bf7f2a2dba216) | `` yara-x: 1.17.0 -> 1.18.0 ``                                                                 |
| [`51c88e55`](https://github.com/NixOS/nixpkgs/commit/51c88e5584a47a6e6093d70613be360a297b3b59) | `` python3Packages.litellm: 1.86.0 -> 1.89.0 ``                                                |
| [`a14675e4`](https://github.com/NixOS/nixpkgs/commit/a14675e4d4e6a3f82da669c98351cfc46718ffd6) | `` sensu-go-agent: 6.14.1 -> 6.14.2 ``                                                         |
| [`26e39177`](https://github.com/NixOS/nixpkgs/commit/26e3917791625583e750fe584be631a4b8216cb3) | `` stylance-cli: 0.8.3 -> 0.8.4 ``                                                             |
| [`ed2c9a70`](https://github.com/NixOS/nixpkgs/commit/ed2c9a706293ad775f761f3f4adf60d37187037a) | `` python3Packages.waqiasync: modernize ``                                                     |
| [`49d66cd4`](https://github.com/NixOS/nixpkgs/commit/49d66cd4ecf8de19d907f7735bf7f5d2ea51c214) | `` python3Packages.waqiasync: migrate to pyproject ``                                          |
| [`d17c7163`](https://github.com/NixOS/nixpkgs/commit/d17c71632f84d2ada1f039cc55089f09deea07b3) | `` space-station-14-launcher: 0.37.1 -> 0.38.0 ``                                              |
| [`64fb7635`](https://github.com/NixOS/nixpkgs/commit/64fb7635549ee6b1bc4188adff61b58be30c6a2f) | `` python3Packages.vsts-cd-manager: modernize ``                                               |
| [`ba8beba1`](https://github.com/NixOS/nixpkgs/commit/ba8beba11e5e944fb29a99d4496354ff90c8bb96) | `` python3Packages.vsts-cd-manager: migrate to pyproject ``                                    |
| [`0b61d609`](https://github.com/NixOS/nixpkgs/commit/0b61d609e41fe8bed5b543c1e9d228175ffb8bf6) | `` traefik-certs-dumper: 2.11.2 -> 2.11.3 ``                                                   |
| [`b247e162`](https://github.com/NixOS/nixpkgs/commit/b247e16291ae9e873abb3c44d0e060159936823b) | `` python3Packages.vqgan-jax: modernize ``                                                     |
| [`665baa5a`](https://github.com/NixOS/nixpkgs/commit/665baa5a9ec14bc69f86205eac32c6f46f201438) | `` python3Packages.vqgan-jax: migrate to pyproject ``                                          |
| [`2f7d4981`](https://github.com/NixOS/nixpkgs/commit/2f7d4981bca14614fce68de99b9a376ddabd20e7) | `` python3Packages.vpk: modernize ``                                                           |
| [`42b9f356`](https://github.com/NixOS/nixpkgs/commit/42b9f35615c2b9bd097ba7fec86ef7b54f5c4d96) | `` python3Packages.vpk: migrate to pyproject ``                                                |
| [`5392e8b8`](https://github.com/NixOS/nixpkgs/commit/5392e8b83bd9e765187cf023e1633a9f287ba1eb) | `` audacity: 3.7.7 -> 3.7.8 ``                                                                 |
| [`8225acf6`](https://github.com/NixOS/nixpkgs/commit/8225acf6d09fa6af795edabf7d49f2126950661e) | `` python3Packages.iamdata: 0.1.202606131 -> 0.1.202606151 ``                                  |
| [`7b6e892e`](https://github.com/NixOS/nixpkgs/commit/7b6e892ead29e5376e9e656e905eeaa7d226ad1c) | `` cm-rgb: migrate to by-name ``                                                               |
| [`429b3932`](https://github.com/NixOS/nixpkgs/commit/429b3932ad9aac93210f6c7b0236f88ea43a7ddd) | `` pass2csv: migrate to by-name ``                                                             |
| [`90e65195`](https://github.com/NixOS/nixpkgs/commit/90e651958e773155b329c0460be6dd12b8ffbe5b) | `` nitrokey-app2: migrate to by-name ``                                                        |
| [`eee73dc6`](https://github.com/NixOS/nixpkgs/commit/eee73dc65ba509d793591a04ee41861904aba7e3) | `` cve-bin-tool: migrate to by-name ``                                                         |
| [`ced166d2`](https://github.com/NixOS/nixpkgs/commit/ced166d25f031097b42dc91fc381b6cbd3ba5c15) | `` vpn-slice: migrate to by-name ``                                                            |
| [`8bba00bf`](https://github.com/NixOS/nixpkgs/commit/8bba00bf25d4ae36487a01f40c9e9c0e6ca3b479) | `` s3cmd: migrate to by-name ``                                                                |
| [`9be71716`](https://github.com/NixOS/nixpkgs/commit/9be717162a4793602642aae8a8dd42d344a83d86) | `` namespaced-openvpn: migrate to by-name ``                                                   |
| [`4ec02b3b`](https://github.com/NixOS/nixpkgs/commit/4ec02b3b4cc1a01c84d4c2e897b8c23158a9ded0) | `` vimwiki-markdown: migrate to by-name ``                                                     |
| [`a172c8d6`](https://github.com/NixOS/nixpkgs/commit/a172c8d65b98cc7abdf29c184f958ff8530bf956) | `` remote-exec: migrate to by-name ``                                                          |
| [`24f4fe66`](https://github.com/NixOS/nixpkgs/commit/24f4fe666e4b33b1220a0e89491fae67482c1dca) | `` pdd: migrate to by-name ``                                                                  |
| [`f31ccd0b`](https://github.com/NixOS/nixpkgs/commit/f31ccd0b1747743a2d7c8f4a720c6161ab2a16ae) | `` opencode{,-desktop}: 1.17.4 -> 1.17.7 ``                                                    |
| [`f333cfa6`](https://github.com/NixOS/nixpkgs/commit/f333cfa682f8d6666880aff6a52e1d501ccf990c) | `` pandoc-tablenos: migrate to by-name ``                                                      |
| [`b703eedd`](https://github.com/NixOS/nixpkgs/commit/b703eedd203eb83fe179728b12881dbec510ae0f) | `` pandoc-secnos: migrate to by-name ``                                                        |
| [`9abcd7e9`](https://github.com/NixOS/nixpkgs/commit/9abcd7e905b40017ee89bfeca10bdc3d06a4104d) | `` pandoc-fignos: migrate to by-name ``                                                        |
| [`9bcc9690`](https://github.com/NixOS/nixpkgs/commit/9bcc9690e99410bd7ef9474082b8d76de458931a) | `` pandoc-eqnos: migrate to by-name ``                                                         |
| [`3c6927e5`](https://github.com/NixOS/nixpkgs/commit/3c6927e59188e49a96a75d2f62d323dbfc263afc) | `` pandoc-plantuml-filter: migrate to by-name ``                                               |
| [`7437d362`](https://github.com/NixOS/nixpkgs/commit/7437d3628c20987a96739f0c9c674d01b24c6c67) | `` pandoc-drawio-filter: migrate to by-name ``                                                 |
| [`161d0eec`](https://github.com/NixOS/nixpkgs/commit/161d0eecaaf35311cab442efb92a7e7979a4f23c) | `` pandoc-include: migrate to by-name ``                                                       |
| [`d94038dc`](https://github.com/NixOS/nixpkgs/commit/d94038dc7120b51bb088a7e65e727e646762d31a) | `` pandoc-imagine: migrate to by-name ``                                                       |
| [`53033ad1`](https://github.com/NixOS/nixpkgs/commit/53033ad1367fc18e111d188643c1080e5e93ce1c) | `` television: 0.15.8 -> 0.15.9 ``                                                             |
| [`2374a452`](https://github.com/NixOS/nixpkgs/commit/2374a452039f0289199468c680cd629037ba45b5) | `` pandoc-acro: migrate to by-name ``                                                          |
| [`0747e884`](https://github.com/NixOS/nixpkgs/commit/0747e884ad75a7b42801eb4c8d486083d2bc2ab7) | `` online-judge-template-g-generator: migrate to by-name ``                                    |
| [`edf28f2d`](https://github.com/NixOS/nixpkgs/commit/edf28f2d92486610f56e52ec983c5bf7c660979f) | `` input-remapper: migrate to by-name ``                                                       |
| [`5b219f4a`](https://github.com/NixOS/nixpkgs/commit/5b219f4aca472522ea2aa169c68c6c5f88ddfdfb) | `` cpupower-gui: migrate to by-name ``                                                         |
| [`877e6293`](https://github.com/NixOS/nixpkgs/commit/877e629311ff58a4ecba08c996f010f9138bd58b) | `` yakut: migrate to by-name ``                                                                |
| [`19c199ec`](https://github.com/NixOS/nixpkgs/commit/19c199ecf9f3bb1ac4948ef900be828ad389fb0a) | `` gdbgui: migrate to by-name ``                                                               |
| [`999b01b8`](https://github.com/NixOS/nixpkgs/commit/999b01b89e6755a5475de8f325b7e5dd3bc1d332) | `` enochecker-test: migrate to by-name ``                                                      |
| [`637abc14`](https://github.com/NixOS/nixpkgs/commit/637abc14d3f6e4700c2c138ba35c2b23a9c52c92) | `` msolve: 0.9.5 -> 0.10.0 ``                                                                  |
| [`2de2a10f`](https://github.com/NixOS/nixpkgs/commit/2de2a10ff59087dec2d70131bbbb7eb61e95a721) | `` asn2quickder: migrate to by-name ``                                                         |
| [`de1ca553`](https://github.com/NixOS/nixpkgs/commit/de1ca5536f9a53d0f22c0e9908baefb304435548) | `` hyprshade: migrate to by-name ``                                                            |
| [`51277308`](https://github.com/NixOS/nixpkgs/commit/51277308b520ed1b144d77e550f839685d538c72) | `` plex-mpv-shim: migrate to by-name ``                                                        |
| [`fda2f105`](https://github.com/NixOS/nixpkgs/commit/fda2f1053772a5daa1904e58928c7a6425430c47) | `` jellyfin-mpv-shim: migrate to by-name ``                                                    |
| [`9c30dc23`](https://github.com/NixOS/nixpkgs/commit/9c30dc238a63ec23922e56feb0426045ede74fd3) | `` sumorobot-manager: migrate to by-name ``                                                    |
| [`86a650ba`](https://github.com/NixOS/nixpkgs/commit/86a650ba837f627ab0755605aeb64ffe3662b35e) | `` mavproxy: migrate to by-name ``                                                             |
| [`23a2251a`](https://github.com/NixOS/nixpkgs/commit/23a2251a4fbb361a86f8571514f0d790b52b4096) | `` matrix-commander: migrate to by-name ``                                                     |
| [`52757fb6`](https://github.com/NixOS/nixpkgs/commit/52757fb65fc8c06bc8ea94f77fd9d9b5a697d06f) | `` droopy: migrate to by-name ``                                                               |
| [`2c4fd9af`](https://github.com/NixOS/nixpkgs/commit/2c4fd9af61f9a2b00162dffb7227098af1a97a30) | `` yokadi: migrate to by-name ``                                                               |
| [`9ff11808`](https://github.com/NixOS/nixpkgs/commit/9ff118082422da0bd342e958c4e61ca21ad507ab) | `` termpdfpy: migrate to by-name ``                                                            |
| [`6427ceea`](https://github.com/NixOS/nixpkgs/commit/6427ceea1fadc52e6092f56b843cb9f2f169ade4) | `` remarkable-mouse: migrate to by-name ``                                                     |
| [`a63cf1c6`](https://github.com/NixOS/nixpkgs/commit/a63cf1c6a418fc461f038df91a9e86b877e82e68) | `` bluetooth_battery: migrate to by-name ``                                                    |
| [`e0efe0fa`](https://github.com/NixOS/nixpkgs/commit/e0efe0fa3b01d90ded22d58e05749a55917770bb) | `` bitwarden-menu: migrate to by-name ``                                                       |
| [`a3b43c83`](https://github.com/NixOS/nixpkgs/commit/a3b43c83bc3dc259ee7f99f60168b0b6449277b0) | `` zotero: 9.0.4 -> 9.0.5 ``                                                                   |
| [`6bb84622`](https://github.com/NixOS/nixpkgs/commit/6bb846221b204f0586c9cbbe1db8d005a1103a57) | `` firefox-esr-140-unwrapped: 141.11.0esr -> 140.12.0esr ``                                    |
| [`d89c0201`](https://github.com/NixOS/nixpkgs/commit/d89c020155fd4284f5e5846a53f917ff4ca3c505) | `` firefox-bin-unwrapped: 151.0.4 -> 152.0 ``                                                  |
| [`e65715b7`](https://github.com/NixOS/nixpkgs/commit/e65715b74d6c1529969efe4dee366d7f535d9b9d) | `` firefox-unwrapped: 151.0.4 -> 152.0 ``                                                      |
| [`b7759b11`](https://github.com/NixOS/nixpkgs/commit/b7759b11f1bff67b9801d222d5013e47450d24ed) | `` yaziPlugins.starship: 0-unstable-2026-03-22 → 0-unstable-2026-06-14 ``                      |
| [`1eba6059`](https://github.com/NixOS/nixpkgs/commit/1eba6059e52c93e85161e5741dfdd9a83535350b) | `` yaziPlugins.mediainfo: 0-unstable-2026-06-03 → 0-unstable-2026-06-06 ``                     |
| [`1d6bde64`](https://github.com/NixOS/nixpkgs/commit/1d6bde6467fb618121ff41599d6126ea6cb1e1a5) | `` umap: switch to finalAttrs, add strictDeps and structuredAttrs, add umapDeps to fix eval `` |
| [`244274d0`](https://github.com/NixOS/nixpkgs/commit/244274d045b858490e9db7942cf1d73eb1526271) | `` gvm-libs: 23.2.2 -> 23.3.0 ``                                                               |
| [`9a58d43e`](https://github.com/NixOS/nixpkgs/commit/9a58d43e69eb1e5b63c54cf7c249088c8892a30a) | `` nss_latest: 3.124 -> 3.125 ``                                                               |
| [`e8bf294a`](https://github.com/NixOS/nixpkgs/commit/e8bf294aba66080b478d4748241ec87e6f6796f9) | `` toml-f: 0.4.3 -> 0.5.1 ``                                                                   |
| [`62da410f`](https://github.com/NixOS/nixpkgs/commit/62da410f886286911999e62086c3b22bc9f6925f) | `` tombi: 1.1.2 -> 1.1.3 ``                                                                    |
| [`f55aa753`](https://github.com/NixOS/nixpkgs/commit/f55aa7534ac7f6dcdd9fa5e76f56c1a4e251440f) | `` scaphandre: correct alias/throw name ``                                                     |
| [`e116dafc`](https://github.com/NixOS/nixpkgs/commit/e116dafc00b86f3c8821d56d4cf3a68efbac0af0) | `` rfc: 1.0.1 -> 2.0.0 ``                                                                      |
| [`63eaf931`](https://github.com/NixOS/nixpkgs/commit/63eaf931b1f457e682f568506a26d5b4ea8b7afe) | `` fluux-messenger: init at 0.16.0 ``                                                          |
| [`b83363a6`](https://github.com/NixOS/nixpkgs/commit/b83363a6226faba2551842df94bc439c1b12dabe) | `` n8n-task-runner-launcher: 1.4.6 -> 1.4.7 ``                                                 |
| [`ec5b622c`](https://github.com/NixOS/nixpkgs/commit/ec5b622cba62e5624530cd0b3276f528aaea0c90) | `` crossmacro-daemon: 1.1.0 -> 1.2.1 ``                                                        |
| [`8b43b8b3`](https://github.com/NixOS/nixpkgs/commit/8b43b8b37a486c8956c51a00ef4deb86ac3f65a0) | `` crossmacro: 1.1.0 -> 1.2.1 ``                                                               |
| [`abb98d5a`](https://github.com/NixOS/nixpkgs/commit/abb98d5adf9acb336ea7f090959fa43c0790d5bd) | `` maintainers: add mkoppmann ``                                                               |
| [`585eb27c`](https://github.com/NixOS/nixpkgs/commit/585eb27cb2879380870b1649cd797b699fb1ab0b) | `` mieru: 3.33.0 -> 3.34.0 ``                                                                  |
| [`0e9ab05b`](https://github.com/NixOS/nixpkgs/commit/0e9ab05ba3a0fe53af403534d2020fac1eb1395a) | `` home-assistant-custom-components.mypyllant: 0.9.13 -> 0.9.16 ``                             |
| [`3c44820a`](https://github.com/NixOS/nixpkgs/commit/3c44820ae18213d2e814e06a2a6c207841af699e) | `` python3.pkgs.mypyllant: 0.9.12 -> 0.9.15 ``                                                 |
| [`c0806c04`](https://github.com/NixOS/nixpkgs/commit/c0806c0451daf3c387fcd41bd85e3f84f38afad4) | `` python3Packages.claude-agent-sdk: 0.2.97 -> 0.2.101 ``                                      |
| [`98c53f95`](https://github.com/NixOS/nixpkgs/commit/98c53f954c5aae70be888284989a893acb8362f6) | `` lagrange: 1.20.6 -> 1.20.7 ``                                                               |
| [`ad078de0`](https://github.com/NixOS/nixpkgs/commit/ad078de08a47462e727e8f47293fc6f696ed7511) | `` gatus: 5.35.0 -> 5.36.0 ``                                                                  |
| [`b0c80036`](https://github.com/NixOS/nixpkgs/commit/b0c8003671a05e45f0d7e5cda8b11c4cf0d8f07b) | `` bcachefs-tools: mark as working on kernel 7.1 ``                                            |
| [`05337c53`](https://github.com/NixOS/nixpkgs/commit/05337c5315d01b86e0d4fa4c7723b189018b40ba) | `` foks: add phanirithvij as maintainer ``                                                     |
| [`870a998b`](https://github.com/NixOS/nixpkgs/commit/870a998b294a8c78514c96c5463c47f51993931d) | `` foks: 0.1.7 -> 0.1.8 ``                                                                     |
| [`f3517984`](https://github.com/NixOS/nixpkgs/commit/f35179843a3afd5f535810a1970ba85d54b5444f) | `` foks-server: convert to an alias ``                                                         |
| [`da9109b9`](https://github.com/NixOS/nixpkgs/commit/da9109b99c89b9928c6bf994eff41c93e4b69be2) | `` ocqPackages.mathcomp-analysis: change how to specify dependencies ``                        |
| [`4eeb6756`](https://github.com/NixOS/nixpkgs/commit/4eeb675665cb6d74334d7750f6b1d4ac97ab4ac5) | `` python3Packages.pubnub: 10.6.3 -> 10.7.0 ``                                                 |
| [`8e376c4f`](https://github.com/NixOS/nixpkgs/commit/8e376c4fbecc60bac12f89dbdfb8bca869bb6100) | `` rocqPackages.mathcomp-analysis: update dependencies ``                                      |
| [`2f225102`](https://github.com/NixOS/nixpkgs/commit/2f225102aa37cecb50c4e6a5d65b6921579165b4) | `` python3Packages.pyexploitdb: 0.3.30 -> 0.3.31 ``                                            |
| [`9658d91c`](https://github.com/NixOS/nixpkgs/commit/9658d91c96da3dee132ca8328675883e16fbc0c8) | `` python3Packages.aiodiscover: 3.3.1 -> 3.3.2 ``                                              |
| [`44bc9dea`](https://github.com/NixOS/nixpkgs/commit/44bc9deaefa2021f4743280466b97fa6c683f217) | `` pip-audit: 2.10.0 -> 2.10.1 ``                                                              |
| [`78f6a17e`](https://github.com/NixOS/nixpkgs/commit/78f6a17e70b64e96de5efbd2fe9205f1bf8e8a84) | `` python3Packages.claude-agent-sdk: 0.2.97 -> 0.2.101 ``                                      |
| [`81f76388`](https://github.com/NixOS/nixpkgs/commit/81f7638837111c249117e5a605ea58741823c32c) | `` python3Packages.cyclopts: 4.17.0 -> 4.18.0 ``                                               |
| [`6128956d`](https://github.com/NixOS/nixpkgs/commit/6128956d19ed3d66cb8a2dd80e68a5c37b04bf4b) | `` nerva: 1.15.0 -> 1.18.1 ``                                                                  |
| [`363fc23d`](https://github.com/NixOS/nixpkgs/commit/363fc23dd36305ce266339bbcf44b50da17e5002) | `` kitty: 0.47.2->0.47.4 ``                                                                    |
| [`eaffa2ad`](https://github.com/NixOS/nixpkgs/commit/eaffa2adf20debd49ab293b93aa4464a1711c705) | `` python3Packages.slowapi: migrate to finalAttrs ``                                           |
| [`4f87ecab`](https://github.com/NixOS/nixpkgs/commit/4f87ecabba040e29a537aea8dfa9401dd926ed7e) | `` python3Packages.tencentcloud-sdk-python: 3.1.114 -> 3.1.115 ``                              |
| [`d08b48f9`](https://github.com/NixOS/nixpkgs/commit/d08b48f9d0dd39b1cc174a51818b87ba23878a14) | `` foks: dedup foks, foks-server derivations ``                                                |
| [`84052d76`](https://github.com/NixOS/nixpkgs/commit/84052d763b06d09f5ba82a8498e4550834e6eb26) | `` leviculum: init at 0.6.0 ``                                                                 |
| [`57252811`](https://github.com/NixOS/nixpkgs/commit/5725281144df3a8f9b4a7c12788e833e755bd56a) | `` pt2-clone: 1.89 -> 1.90 ``                                                                  |
| [`8d3bc2ec`](https://github.com/NixOS/nixpkgs/commit/8d3bc2ec905e65f268daacbfbbc730aec6f7b5fc) | `` athens: 0.17.1 -> 0.18.0 ``                                                                 |
| [`a51221bb`](https://github.com/NixOS/nixpkgs/commit/a51221bbc9a2440f91f47a4fc28ce01388f4806f) | `` cosign: 3.0.6 -> 3.1.1 ``                                                                   |
| [`9c1782e0`](https://github.com/NixOS/nixpkgs/commit/9c1782e0bf9b3f874d9addd23e03efa55ca94e02) | `` terraform-providers.baidubce_baiducloud: 1.23.2 -> 1.23.3 ``                                |
| [`0bbca741`](https://github.com/NixOS/nixpkgs/commit/0bbca7411153835ff74c2da4b6bdb8917f159d23) | `` renode-dts2repl: 0-unstable-2026-05-28 -> 0-unstable-2026-06-08 ``                          |
| [`29c21f3a`](https://github.com/NixOS/nixpkgs/commit/29c21f3a58e21602dac36dfdbb3f27dbc836773d) | `` keifu: 0.3.0 -> 0.4.0 ``                                                                    |
| [`71859186`](https://github.com/NixOS/nixpkgs/commit/71859186f2d55f21bcef4eb9b147480180a90515) | `` python3Packages.codecarbon: 3.2.7 -> 3.2.8 ``                                               |
| [`c51fecda`](https://github.com/NixOS/nixpkgs/commit/c51fecdad34729650e19b2fc81f8a7a721c216eb) | `` panache: 2.51.0 -> 2.54.0 ``                                                                |
| [`32806179`](https://github.com/NixOS/nixpkgs/commit/32806179bd89c120dde0a1d3d39cf013b21e4e87) | `` python3Packages.slowapi: 0.1.9 -> 0.1.10 ``                                                 |
| [`c5b2a68b`](https://github.com/NixOS/nixpkgs/commit/c5b2a68bf8cce549afd5d9fe24d399c735aa443f) | `` python3Packages.paddleocr: 3.6.1 -> 3.7.1 ``                                                |
| [`f89df3d5`](https://github.com/NixOS/nixpkgs/commit/f89df3d528b8c1012dc5e280c60fdb823aa4e490) | `` libretro.flycast: 0-unstable-2026-06-05 -> 0-unstable-2026-06-12 ``                         |
| [`d7ff934c`](https://github.com/NixOS/nixpkgs/commit/d7ff934c3dce9ae96272a4287cfb82438ed2e429) | `` vscode-extensions.ban.spellright: 3.0.148 -> 3.0.154 ``                                     |
| [`889a4f48`](https://github.com/NixOS/nixpkgs/commit/889a4f48f72a8a24b6bc6c11a5442fab412a7db4) | `` sigsum: 0.14.0 -> 0.14.1 ``                                                                 |
| [`2ec3399f`](https://github.com/NixOS/nixpkgs/commit/2ec3399f543884d90c8d006f563efe4a12d9062e) | `` plasticscm-client-core-unwrapped: 11.0.16.9998 -> 11.0.16.10216 ``                          |
| [`42bf783e`](https://github.com/NixOS/nixpkgs/commit/42bf783edfea5d061c8845f253b6e0484a6dd5b8) | `` plasticscm-theme: 11.0.16.9998 -> 11.0.16.10216 ``                                          |
| [`d04a4abe`](https://github.com/NixOS/nixpkgs/commit/d04a4abe9970fef3e6e9d1bdee2bfff3392869e2) | `` plasticscm-client-gui-unwrapped: 11.0.16.9998 -> 11.0.16.10216 ``                           |
| [`f9b39207`](https://github.com/NixOS/nixpkgs/commit/f9b3920704bcd0e67c5e2027c3383ae63c6b8751) | `` i18next-cli: 1.61.0 -> 1.63.1 ``                                                            |
| [`afc1a37f`](https://github.com/NixOS/nixpkgs/commit/afc1a37f6c40bc0fa8bcedfb0c32ae0459c869ff) | `` python3Packages.microsoft-kiota-authentication-azure: 1.10.2 -> 1.10.3 ``                   |
| [`d01f4360`](https://github.com/NixOS/nixpkgs/commit/d01f43605c39598093aecc98290e15680de34e75) | `` python3Packages.zigpy-zboss: 2.0.0 -> 2.0.1 ``                                              |
| [`956c381f`](https://github.com/NixOS/nixpkgs/commit/956c381f30ad0682faac8c834ca44ff8bae522e2) | `` zk: 0.15.4 -> 0.15.5 ``                                                                     |
| [`dfff249f`](https://github.com/NixOS/nixpkgs/commit/dfff249f7c9da2afacbb30635b19cac69414aa1b) | `` yek: 0.25.3 -> 0.25.4 ``                                                                    |
| [`862f51c2`](https://github.com/NixOS/nixpkgs/commit/862f51c2ef98c6d247a75277e014badcb0a72e3a) | `` xdg-desktop-portal-termfilechooser: 1.4.0 -> 1.4.3 ``                                       |
| [`4a7d7f30`](https://github.com/NixOS/nixpkgs/commit/4a7d7f30165ee151fd9fd84483298aa66d855377) | `` obs-studio-plugins.obs-vertical-canvas: 1.6.2 -> 1.6.4 ``                                   |
| [`ff61ee56`](https://github.com/NixOS/nixpkgs/commit/ff61ee562bd057191d291366a8b2d9c393c42924) | `` uwsm: 0.26.4 -> 0.26.5 ``                                                                   |
| [`12915d17`](https://github.com/NixOS/nixpkgs/commit/12915d17919776c548d0cd577bbc24d1351edabd) | `` terraform-providers.hashicorp_google: 7.35.0 -> 7.36.0 ``                                   |
| [`a490c978`](https://github.com/NixOS/nixpkgs/commit/a490c978630ac86733817018e804069d6624684a) | `` vscode: 1.123.0 -> 1.124.2 ``                                                               |
| [`0f243861`](https://github.com/NixOS/nixpkgs/commit/0f243861824ef006ebb62617dc89d3d0c7a3ed80) | `` fut: 3.3.3 -> 3.3.4 ``                                                                      |
| [`8db2f0fa`](https://github.com/NixOS/nixpkgs/commit/8db2f0fa16eb7a63f7ac2de20daf7b21c1c04cf4) | `` vouch-proxy: 0.47.2 -> 0.48.0 ``                                                            |
| [`79d52c41`](https://github.com/NixOS/nixpkgs/commit/79d52c4140d8df686dc7cb1788ab5e805bd7e626) | `` lighttpd: 1.4.82 -> 1.4.83 ``                                                               |
| [`f9febb7d`](https://github.com/NixOS/nixpkgs/commit/f9febb7d44e221a93dcf63d5c7dbaf5bb838bdd8) | `` vrrtest: 2.1.0 -> 2.1.1 ``                                                                  |
| [`09a67eec`](https://github.com/NixOS/nixpkgs/commit/09a67eecf05f1c9ee357874d1fb1cc54b4577d2c) | `` phpactor: 2026.05.30.1 -> 2026.05.30.2 ``                                                   |
| [`3aba1ee7`](https://github.com/NixOS/nixpkgs/commit/3aba1ee7d9c1ca8bb82563dd23c00bed24e0f903) | `` nixos/tests/pretalx: migrate to nspawn ``                                                   |
| [`f6ba286b`](https://github.com/NixOS/nixpkgs/commit/f6ba286b289ba4a2ed70898c7afd2ed24deaa5fc) | `` nixos/tests/pretix: migrate to nspawn ``                                                    |
| [`aa8c9f5d`](https://github.com/NixOS/nixpkgs/commit/aa8c9f5d9a1cbefcb9886df41d4502048866ea27) | `` nixos/pretalx: remove elevation from the pretalx-manage wrapper ``                          |
| [`091abce8`](https://github.com/NixOS/nixpkgs/commit/091abce8363b2aa5f39303d32e79b5986842a927) | `` nixos/pretix: remove elevation from pretix-manage wrapper ``                                |
| [`2f2bba6b`](https://github.com/NixOS/nixpkgs/commit/2f2bba6b56f49cbf9f214e33b38f901fc95abf45) | `` nixos/tests/systemd-networkd-ipv6-prefix-delegation: run in nspawn ``                       |
| [`fec2f10b`](https://github.com/NixOS/nixpkgs/commit/fec2f10b70772e58f20cff187593f73b5042df3d) | `` nixosTests.kea: migrate to nspawn ``                                                        |
| [`eff316c8`](https://github.com/NixOS/nixpkgs/commit/eff316c84d19fa0f7e8d11b956b872c6e6c31a50) | `` python3Packages.paddlex: 3.6.1 -> 3.7.1 ``                                                  |
| [`84558b85`](https://github.com/NixOS/nixpkgs/commit/84558b851369773dfcf96e166c0c02d1f68fac4b) | `` pdm: 2.26.6 -> 2.27.0 ``                                                                    |
| [`605519e2`](https://github.com/NixOS/nixpkgs/commit/605519e2ea16977ed2d1799596d74d2cfb788fe5) | `` python3Packages.unearth: unbreak with patch from upstream ``                                |
| [`42c99731`](https://github.com/NixOS/nixpkgs/commit/42c99731b5a09e58f479291980d05964a2bae81a) | `` wayscriber: 0.9.19 -> 0.9.20 ``                                                             |
| [`25f58f9d`](https://github.com/NixOS/nixpkgs/commit/25f58f9d7cfafe0092399d9a3605189ce680afbd) | `` perlPackages.CatalystPluginAuthentication: 0.10023 -> 0.10_027 ``                           |
| [`ae8aedc9`](https://github.com/NixOS/nixpkgs/commit/ae8aedc9b89b4abc48ba4fd1071361d11f061f14) | `` waymore: 6.5 -> 8.9 ``                                                                      |
| [`f9e8d1aa`](https://github.com/NixOS/nixpkgs/commit/f9e8d1aa0c5ce7dc6f7b5a91f8e3c85e5f308a51) | `` shopware-cli: 0.15.3 -> 0.15.5 ``                                                           |
| [`48e6d966`](https://github.com/NixOS/nixpkgs/commit/48e6d9662e373c29ea961b8978306cb1d55a1e5c) | `` python3Packages.torchao: disable failing test on darwin (unknown FP type) ``                |
| [`b0114bd3`](https://github.com/NixOS/nixpkgs/commit/b0114bd38431140851d00d304e3d26d2aa12605f) | `` python3Packages.tinygrad: fix test failing with safetensors 0.8.0 ``                        |
| [`c988d71d`](https://github.com/NixOS/nixpkgs/commit/c988d71ddc2933ce8cc804dfbe35d6de7233b25e) | `` python3Packages.onnx-ir: fix safetensors 0.8.0 compat ``                                    |
| [`2acce6ab`](https://github.com/NixOS/nixpkgs/commit/2acce6ab8a990a6782eddc640d94ca4ab770d03d) | `` python3Packages.safetensors: 0.7.0 -> 0.8.0 ``                                              |
| [`53be6288`](https://github.com/NixOS/nixpkgs/commit/53be62886a25e78ea04a8b3150678b8d4866aa00) | `` python3Packages.githubkit: 0.14.4 -> 0.16.0 ``                                              |
| [`f89318fc`](https://github.com/NixOS/nixpkgs/commit/f89318fc103346e7b116dd44b6f11f513e0481ae) | `` python3Packages.hishel: 1.1.10 -> 1.3.0 ``                                                  |
| [`db928c3a`](https://github.com/NixOS/nixpkgs/commit/db928c3aa95aaf279262c23317f9c4aa36f71f42) | `` sub-store-frontend: 2.17.31 -> 2.17.36 ``                                                   |
| [`31fce501`](https://github.com/NixOS/nixpkgs/commit/31fce501878a57db0ea901f3ad5a097aa8d5c352) | `` cz-cli: 4.3.0 -> 4.3.2 ``                                                                   |
| [`2fdbe4a5`](https://github.com/NixOS/nixpkgs/commit/2fdbe4a59b85bf31ff9ac04f3739e55ffabdd276) | `` parca-agent: 0.47.1 -> 0.48.0 ``                                                            |
| [`ed3265a1`](https://github.com/NixOS/nixpkgs/commit/ed3265a13fb00b883abce76358cf16f2801de234) | `` various: address `lint-short-path-literals` ``                                              |
| [`23aa189e`](https://github.com/NixOS/nixpkgs/commit/23aa189e95bb3305445ce29d83df6c70cbd6c79a) | `` zeroclaw: 0.7.5 -> 0.8.0 ``                                                                 |
| [`63e021e4`](https://github.com/NixOS/nixpkgs/commit/63e021e4c7ddfb2fe4810699caf77e539a0d57bf) | `` python3Packages.pyupdate: drop ``                                                           |
| [`ad56b9a8`](https://github.com/NixOS/nixpkgs/commit/ad56b9a886d6d04687c74119f4985f38b0e3a615) | `` rumdl: 0.2.8 -> 0.2.16 ``                                                                   |
| [`babcc96a`](https://github.com/NixOS/nixpkgs/commit/babcc96ab6f2db2d7ad56a9abde89fe9c460c71f) | `` python3Packages.matter-ble-proxy: 0.8.0 -> 1.0.0 ``                                         |
| [`eee4e956`](https://github.com/NixOS/nixpkgs/commit/eee4e956e4c433743bc2ca7c76f2f294ad653eb9) | `` ghciwatch: 1.3.5 -> 1.4.1 ``                                                                |
| [`86f2b2c9`](https://github.com/NixOS/nixpkgs/commit/86f2b2c9d5d077220bb3b28a05317c2559f056d6) | `` s-tui: 1.3.0 -> 1.4.0 ``                                                                    |
| [`4a6280f8`](https://github.com/NixOS/nixpkgs/commit/4a6280f84defb5846ce887f154d8eee173d40825) | `` mitra: 4.17.0 -> 5.0.0 ``                                                                   |
| [`0e9f1ddd`](https://github.com/NixOS/nixpkgs/commit/0e9f1ddd1bd80990ffff4cb37c7d35d1db0e14c1) | `` python3Packages.a2a-sdk: disable tests that fail on Darwin ``                               |
| [`656e11ac`](https://github.com/NixOS/nixpkgs/commit/656e11ac2db93d39ba30fe34b99b7a67b68fbc50) | `` makemkv: fix missing icon on Gnome ``                                                       |
| [`458f4ef4`](https://github.com/NixOS/nixpkgs/commit/458f4ef48eeac51057b56f004da841f56e184349) | `` nixos/syncthing: fix folder device ID name resolution ``                                    |
| [`de846cf3`](https://github.com/NixOS/nixpkgs/commit/de846cf326abe239e5675c35c105857c7e3a6669) | `` firefox-sync-client: 1.9.0 -> 1.10.0 ``                                                     |
| [`10d7376f`](https://github.com/NixOS/nixpkgs/commit/10d7376fb70ebd0f7c939f8380b38d6c0cb290c2) | `` llmfit: 0.9.30 -> 0.9.31 ``                                                                 |
| [`2f38420d`](https://github.com/NixOS/nixpkgs/commit/2f38420d34ffe9034574e8813224ef0342aa61cf) | `` nixos/music-assistant: Add squeezelite/slimproto firewall ports ``                          |
| [`03c1be3c`](https://github.com/NixOS/nixpkgs/commit/03c1be3cacf9f45ec35a3828310894257662a163) | `` i3altlayout: migrate to pyproject ``                                                        |
| [`ce09d2c3`](https://github.com/NixOS/nixpkgs/commit/ce09d2c37e1fef9fa524779cee86d8f712732432) | `` i3altlayout: enable __structuredAttrs ``                                                    |
| [`8f634707`](https://github.com/NixOS/nixpkgs/commit/8f6347076c7c82e43eb7fc4fbac4df0d897054a2) | `` emacs.pkgs.jabber: build with OMEMO support ``                                              |
| [`95e5b232`](https://github.com/NixOS/nixpkgs/commit/95e5b232f3c307bf3c2d288813bdfbc589687529) | `` wrtag: 0.31.0 -> 0.32.0 ``                                                                  |
| [`756598ad`](https://github.com/NixOS/nixpkgs/commit/756598ad50ce1894bc855fb27b3f0a03ee33b06b) | `` vscode-extensions.ms-python.pylint: 2026.4.0 -> 2026.6.0 ``                                 |
| [`cc0dffb5`](https://github.com/NixOS/nixpkgs/commit/cc0dffb533648f05e1e4ac1f39e7b5a5f9eb75b6) | `` snapraid: 14.5 -> 14.7 ``                                                                   |
| [`8f2bb264`](https://github.com/NixOS/nixpkgs/commit/8f2bb264627917d49eb1cf5fedfedc9df0602e40) | `` oci-cli: 3.85.0 -> 3.86.0 ``                                                                |
| [`e16bf067`](https://github.com/NixOS/nixpkgs/commit/e16bf06715add1cddcb0a195dcc3cd21c0a1b48d) | `` tigerbeetle: 0.17.5 -> 0.17.6 ``                                                            |
| [`29dff8cf`](https://github.com/NixOS/nixpkgs/commit/29dff8cf526b320e30be14e6f97ea1ed0c6afb0e) | `` python3Packages.pydroplet: 2.3.4 -> 2.4.0 ``                                                |
| [`d95830c4`](https://github.com/NixOS/nixpkgs/commit/d95830c43e7136129fbe704d0799de31c9e17a46) | `` prqlc: 0.13.12 -> 0.13.13 ``                                                                |
| [`f9901a79`](https://github.com/NixOS/nixpkgs/commit/f9901a79e03cddd94d67c8b0fa287f69ff0b99f0) | `` xenia-canary: 0-unstable-2026-06-05 -> 0-unstable-2026-06-14 ``                             |
| [`e5bd05c7`](https://github.com/NixOS/nixpkgs/commit/e5bd05c78595c29bceb6a95179de2a00f96aaff4) | `` python3Packages.pygit2: 1.19.1 -> 1.19.3 ``                                                 |
| [`fa89f0f3`](https://github.com/NixOS/nixpkgs/commit/fa89f0f30eb2def01404b84223bdf13ecd1578e3) | `` kubernetes-helmPlugins.helm-unittest: 1.1.0 -> 1.1.1 ``                                     |
| [`f2084f34`](https://github.com/NixOS/nixpkgs/commit/f2084f348194895ecd033b72c01dd8c871bac542) | `` python3Packages.anthropic: 0.97.0 -> 0.109.1 ``                                             |
| [`69fb8c20`](https://github.com/NixOS/nixpkgs/commit/69fb8c204d2c1f511ecb098f32e55be645676277) | `` microsoft-edge: 149.0.4022.52 -> 149.0.4022.69 ``                                           |
| [`81707a38`](https://github.com/NixOS/nixpkgs/commit/81707a38fae0cae043fe0bbe4b91e142545ac30d) | `` turingdb: fix cudaSupport ``                                                                |
| [`bcb2907c`](https://github.com/NixOS/nixpkgs/commit/bcb2907c6261eaa8ac7a836e377ac853e0d39043) | `` colmap: fix CUDA support ``                                                                 |
| [`3dbdf4f0`](https://github.com/NixOS/nixpkgs/commit/3dbdf4f0555b819fc086b37ddc5ca2b07181fa30) | `` faiss: fix cmake CUDA logic to fix downstream consumers ``                                  |
| [`ab847291`](https://github.com/NixOS/nixpkgs/commit/ab8472918ce4700adb69bed24c723601b7881c34) | `` colmap: cleanup, fix on aarch64-linux and on darwin ``                                      |
| [`6922fbdf`](https://github.com/NixOS/nixpkgs/commit/6922fbdfdb543b45bccbd4d43a245e263a7e9378) | `` emacs.pkgs.jabber: 0.10.5 -> 0.11.0 ``                                                      |
| [`3b6239c3`](https://github.com/NixOS/nixpkgs/commit/3b6239c340d2c5a5026a36da859594412f4ee16d) | `` emacs.pkgs.keymap-popup: init at 0.3.1 ``                                                   |
| [`de7f6cdd`](https://github.com/NixOS/nixpkgs/commit/de7f6cdd13089069c104f55d6b73892de4d02068) | `` ffmpeg: Exclude known-broken test on big-endian ``                                          |
| [`c0f363a7`](https://github.com/NixOS/nixpkgs/commit/c0f363a710c7af956841f71da1b9a4da01c0b0f1) | `` lomiri.lomiri-terminal-app: 2.0.5 -> 2.0.6 ``                                               |
| [`a92df62a`](https://github.com/NixOS/nixpkgs/commit/a92df62a1525cf757f8b15a2254fc73d23f4aa6f) | `` clouddrive2: 1.0.8 -> 1.0.10 ``                                                             |
| [`4c07c144`](https://github.com/NixOS/nixpkgs/commit/4c07c144c08c973d139f239c8f49f78b5e18f301) | `` vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.78 -> 1.1.79 ``                   |
| [`98271115`](https://github.com/NixOS/nixpkgs/commit/98271115bc67cbdb24cebff2b6b6d8adecd305aa) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 2.2.0 -> 2.3.0 ``                      |
| [`e53cdaa9`](https://github.com/NixOS/nixpkgs/commit/e53cdaa99404d07e1fffe5279b7bfd4600960d45) | `` lsh: 1.5.8 -> 1.6.1 ``                                                                      |
| [`fe366690`](https://github.com/NixOS/nixpkgs/commit/fe36669082caaefa96b0d9b67b7f4e22097bcb42) | `` linux_7_1: init at 7.1 ``                                                                   |
| [`5a9fb899`](https://github.com/NixOS/nixpkgs/commit/5a9fb8993d63607cc87ef32ccbd8c9df75fb6f9e) | `` python3Packages.curl-cffi: add missing `rich` dependency ``                                 |
| [`6ac0afc5`](https://github.com/NixOS/nixpkgs/commit/6ac0afc5ea896891cb3adc48e8434ff8bb52b768) | `` libretro.beetle-psx: 0-unstable-2026-06-02 -> 0-unstable-2026-06-14 ``                      |
| [`730d8270`](https://github.com/NixOS/nixpkgs/commit/730d82700790b92a1f1401ae6b79c5dbc5b57084) | `` fastfetch: disable enlightment by default ``                                                |
| [`9ff193b8`](https://github.com/NixOS/nixpkgs/commit/9ff193b858b6aa3fac48dee1b813e0bf19a7b532) | `` backintime-common: Add dependency on fuse3 ``                                               |
| [`ce9d2fa0`](https://github.com/NixOS/nixpkgs/commit/ce9d2fa07d5bb74b258e98d18255b6470c2f189f) | `` python3Packages.symbolic: 13.1.1 -> 13.2.0 ``                                               |
| [`c9c19e04`](https://github.com/NixOS/nixpkgs/commit/c9c19e04b9c5fa8fddc1845fa60b304851b246c9) | `` lxmf: init at 1.0.1 ``                                                                      |
| [`6b3c3419`](https://github.com/NixOS/nixpkgs/commit/6b3c34197faaebf25f079e985572b3b2ffe141e3) | `` nomadnet: init at 1.2.0 ``                                                                  |
| [`f96f620e`](https://github.com/NixOS/nixpkgs/commit/f96f620edb7740587f029a6c9e545fb185d3198d) | `` rns-proxy: init at 0.1.0 ``                                                                 |
| [`bb661635`](https://github.com/NixOS/nixpkgs/commit/bb6616359683bd8d72bed397c971851a8c6665f5) | `` bazel_8: 8.6.0 -> 8.7.0 ``                                                                  |
| [`069f6dab`](https://github.com/NixOS/nixpkgs/commit/069f6dabaec91385c1a941ed4faf202aabfb05f2) | `` warp-terminal: 0.2026.06.03.09.49.stable_01 -> 0.2026.06.10.09.27.stable_01 ``              |
| [`2f026217`](https://github.com/NixOS/nixpkgs/commit/2f02621784eabbcc3482ea8fef62aeeeee3a43b8) | `` helmfile: 1.5.2 -> 1.5.3 ``                                                                 |
| [`9013a3ba`](https://github.com/NixOS/nixpkgs/commit/9013a3ba718688d69e2d1f2019ed86740a0e2689) | `` python3Packages.pyotp: 2.9.0 -> 2.10.0 ``                                                   |
| [`f701f68b`](https://github.com/NixOS/nixpkgs/commit/f701f68ba0db315505da52c243e007922328de05) | `` voicevox: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                                    |
| [`730875f9`](https://github.com/NixOS/nixpkgs/commit/730875f9e64eab47ac2cc999eb0155c1c4255d8d) | `` teams-for-linux: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                             |
| [`92c17ecc`](https://github.com/NixOS/nixpkgs/commit/92c17ecc75c7bc3ee6f5a4b2b99033d5f2ec80b6) | `` super-productivity: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                          |
| [`524f9353`](https://github.com/NixOS/nixpkgs/commit/524f9353a2fc45c4fe8d71510e0147370f0bde53) | `` signal-desktop: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                              |
| [`cd3edd50`](https://github.com/NixOS/nixpkgs/commit/cd3edd505edadee81a5e7cd69ddd8c6eb890fab5) | `` opencode-desktop: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                            |
| [`0d9c3cc5`](https://github.com/NixOS/nixpkgs/commit/0d9c3cc57e8e9ac471f541c29cffba62865f37ea) | `` mqtt-explorer: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                               |
| [`eac6f84b`](https://github.com/NixOS/nixpkgs/commit/eac6f84bdc31200d76282bdcfe8c04e91c01c2d8) | `` kando: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                                       |
| [`74fa738d`](https://github.com/NixOS/nixpkgs/commit/74fa738dc84877048189274a466f3780061634b0) | `` gridtracker2: remove usage of CSC_IDENTITY_AUTO_DISCOVERY, refactor ``                      |
| [`dd7d6f11`](https://github.com/NixOS/nixpkgs/commit/dd7d6f1134602bde2ade04b818ce6f45c8136c21) | `` drawio: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                                      |
| [`9e2a7c67`](https://github.com/NixOS/nixpkgs/commit/9e2a7c6780974c1084e6cb9faee81cb68a7ca682) | `` bitwarden-desktop: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                           |
| [`aecf152c`](https://github.com/NixOS/nixpkgs/commit/aecf152c14ab6f8569e301a454b59388ec857a96) | `` radicale: 3.7.4 -> 3.7.5 ``                                                                 |
| [`ab7db15c`](https://github.com/NixOS/nixpkgs/commit/ab7db15c69ce1836eecfb26b374c46e7f87a81a8) | `` nixos/scx-loader: fix failure to run when `/etc` is immutable ``                            |
| [`3a5c240f`](https://github.com/NixOS/nixpkgs/commit/3a5c240ffece70c76c3ee8a3fc8a724569b845a8) | `` tests.replaceVars: fix group mismatches ``                                                  |
| [`85912a42`](https://github.com/NixOS/nixpkgs/commit/85912a429b60c51d316fe33bb9524f41096abe94) | `` tests.trivial-builders.symlinkJoin: fix group mismatches ``                                 |
| [`52a5a3bd`](https://github.com/NixOS/nixpkgs/commit/52a5a3bdd7ae63d08c6015a30ee10ae0ae030786) | `` librewolf: mark with knownVulnerabilities ``                                                |
| [`031be8db`](https://github.com/NixOS/nixpkgs/commit/031be8db4a82e8bf56d49988a2df049188f29b9a) | `` autologin: update homepage ``                                                               |
| [`243695ad`](https://github.com/NixOS/nixpkgs/commit/243695ad141f254b969a46c4ac823f4790ac5800) | `` xandikos: 0.4.0 -> 0.4.2 ``                                                                 |
| [`32256def`](https://github.com/NixOS/nixpkgs/commit/32256defcca437e61ed355216e773b4802b39902) | `` vimPlugins.avante-nvim: copy compiled libraries instead of symlinking ``                    |
| [`8b199629`](https://github.com/NixOS/nixpkgs/commit/8b1996291dc3c26d39d91c9b01417b97f0e062fb) | `` hayagriva: 0.10.0 -> 0.10.1 ``                                                              |
| [`a8ed87e8`](https://github.com/NixOS/nixpkgs/commit/a8ed87e8da9d17967322f9e73115d89ac3c78e72) | `` deno: 2.8.2 -> 2.8.3 ``                                                                     |
| [`f77a2604`](https://github.com/NixOS/nixpkgs/commit/f77a2604932049d0cbd5e933f2d2609217e04bc5) | `` albyhub: add startup test ``                                                                |
| [`71e587c3`](https://github.com/NixOS/nixpkgs/commit/71e587c334628cb718f26b59be384e3bf2585037) | `` albyhub: 1.22.2 -> 1.23.0 ``                                                                |
| [`29fbfd10`](https://github.com/NixOS/nixpkgs/commit/29fbfd106ff5422b264ca9a40ef4ba28f609f347) | `` python3Packages.victron-mqtt: 2026.6.1 -> 2026.6.4 ``                                       |
| [`93ac663a`](https://github.com/NixOS/nixpkgs/commit/93ac663ae2ac31b38607f44d2c89f6b3139dd0f6) | `` diffoscope: add mdaniels5757 as co-maintainer ``                                            |
| [`4fd0f759`](https://github.com/NixOS/nixpkgs/commit/4fd0f759fbe88b1a57902871cf4ba4a2e4f63355) | `` flutter344: init at 3.44.2 ``                                                               |
| [`66c6ebbf`](https://github.com/NixOS/nixpkgs/commit/66c6ebbf0025be7673d46b0b4306a044e39ba68a) | `` xfr: 0.9.14 -> 0.9.19 ``                                                                    |
| [`7fa1b4c6`](https://github.com/NixOS/nixpkgs/commit/7fa1b4c6285e9cda8a5ba470fa61ef4dcb4313e1) | `` zashboard: 3.7.1 -> 3.9.0 ``                                                                |
| [`f42490dc`](https://github.com/NixOS/nixpkgs/commit/f42490dc69e23762d04a06b167432c6bf7bf80ea) | `` sink-rotate: update src and accept upstream versioning ``                                   |
| [`e6c24f11`](https://github.com/NixOS/nixpkgs/commit/e6c24f11ef1dff8112072c0c7fb68dbe9903756f) | `` google-alloydb-auth-proxy: 1.15.0 -> 1.15.1 ``                                              |
| [`633dc17a`](https://github.com/NixOS/nixpkgs/commit/633dc17a6624ff82c6f70d1c739dea1aa0ae98b8) | `` openocd-rp2040: move override to pkgs/by-name ``                                            |
| [`ba10b5f5`](https://github.com/NixOS/nixpkgs/commit/ba10b5f5b1fd95d7a659172ecc0b8e4f2470057f) | `` dalfox: 3.0.2 -> 3.1.0 ``                                                                   |
| [`578a0d3e`](https://github.com/NixOS/nixpkgs/commit/578a0d3e39d1520ebaf0dbf3146c18e308e8b03c) | `` python3Packages.portion: 2.6.1 -> 2.6.2 ``                                                  |
| [`ceee92f9`](https://github.com/NixOS/nixpkgs/commit/ceee92f9a3f400b84a52faf2cc40940be38faea6) | `` terraform-providers.oracle_oci: 8.17.0 -> 8.18.0 ``                                         |
| [`16a84aac`](https://github.com/NixOS/nixpkgs/commit/16a84aac3ceb6ac8802c702baed6638d19e4bf10) | `` python3Packages.kserve: 0.18.0 -> 0.19.0 ``                                                 |
| [`3ab17788`](https://github.com/NixOS/nixpkgs/commit/3ab17788bb26ffb4f4593071628fd2887cab78b6) | `` proton-authenticator: fix crash on Wayland ``                                               |
| [`29647e2b`](https://github.com/NixOS/nixpkgs/commit/29647e2b83db0e1d681fcf501e1994d35c26b6d9) | `` maintainers: add haansn08 ``                                                                |
| [`400f7150`](https://github.com/NixOS/nixpkgs/commit/400f7150d984a895cd48c8fdc9bffd17362f60d0) | `` python3Packages.cartopy: cleanup, fix ``                                                    |
| [`3b3556e3`](https://github.com/NixOS/nixpkgs/commit/3b3556e3ef0c45a7f400103820d96df69575b8ff) | `` lemminx: 0.31.0 -> 0.31.2 ``                                                                |
| [`2970fe74`](https://github.com/NixOS/nixpkgs/commit/2970fe74cbe750945cc37ec3ee0b67f87f85df0b) | `` python3Packages.sunpy: 7.1.0 -> 7.1.2 ``                                                    |
| [`bbd7e87d`](https://github.com/NixOS/nixpkgs/commit/bbd7e87d3b1d811cc39bfcf34e1ca886ab39c94a) | `` python3Packages.bch: modernize ``                                                           |
| [`615d7c59`](https://github.com/NixOS/nixpkgs/commit/615d7c597dc93ba300e06977965f2fe4041be6d7) | `` terraform-providers.venafi_venafi: 0.23.1 -> 0.23.2 ``                                      |
| [`aca9d6bc`](https://github.com/NixOS/nixpkgs/commit/aca9d6bc1583d88ecf4225b2b168aaba2803f88a) | `` python3Packages.brotli-asgi: modernize ``                                                   |
| [`a40b1f6d`](https://github.com/NixOS/nixpkgs/commit/a40b1f6d99d7b8e05a20097d6916b925f3244c98) | `` python3Packages.awesome-slugify: drop ``                                                    |
| [`5ad26e36`](https://github.com/NixOS/nixpkgs/commit/5ad26e362d2e1ccbe7cbc512b422a74e6a325293) | `` haskell.packages.ghc912.glib: patch incompatibility with rts ``                             |
| [`5b8ebc56`](https://github.com/NixOS/nixpkgs/commit/5b8ebc5663b20d9da87e0ba42631e124f12102cf) | `` rapidcsv: 8.97 -> 8.99 ``                                                                   |
| [`42e13427`](https://github.com/NixOS/nixpkgs/commit/42e134272909bd79765e5e872b67f0ddf71f8942) | `` statix: 0-unstable-2026-05-14 -> 0.5.8-unstable-2026-06-13 ``                               |
| [`1b4b1154`](https://github.com/NixOS/nixpkgs/commit/1b4b11544adc936c2161c554e86baf40aab04c9f) | `` emhash: 1.0.1 -> 1.1.0 ``                                                                   |
| [`6a5251ad`](https://github.com/NixOS/nixpkgs/commit/6a5251ade3c4d0f39ac327d09c2605fadb8c1d42) | `` mpvScripts.twitch-chat: 0-unstable-2025-05-15 -> 0-unstable-2026-06-13 ``                   |
| [`d3c0c359`](https://github.com/NixOS/nixpkgs/commit/d3c0c359910d5ce910111f68292c98c4a41821f9) | `` python3Packages.pyenvisalink: 4.9 -> 4.10 ``                                                |
| [`7d3544fd`](https://github.com/NixOS/nixpkgs/commit/7d3544fdcd3e126d12c761ecf0099b7475ee2423) | `` screenly-cli: 1.1.1 -> 1.2.0 ``                                                             |
| [`4f241557`](https://github.com/NixOS/nixpkgs/commit/4f241557fbd005e5bf86c9cb7f4a74d4ef39b4a4) | `` ocamlPackages.aeneas: 2026.06.12 -> 2026.06.14 ``                                           |
| [`589c5f09`](https://github.com/NixOS/nixpkgs/commit/589c5f0938307135fb0403e5d7ef2336f39dbd7b) | `` ocamlPackages.charon: 2026.06.12 -> 2026.06.14 ``                                           |
| [`eb28079d`](https://github.com/NixOS/nixpkgs/commit/eb28079d8764d1b325c97b024488d8b5573625a5) | `` nixosTests/prometheus-exporters/nextcloud: fix robustness ``                                |
| [`b53df16c`](https://github.com/NixOS/nixpkgs/commit/b53df16cc91c3b3316c33206a785d1a7eecdcbe7) | `` nixos/tests/prometheus-exporters: disable orderly shutdown ``                               |
| [`efbf4170`](https://github.com/NixOS/nixpkgs/commit/efbf4170910c66822ba84972ef721c79a5df3bc2) | `` nixos/tests/prometheus-exporters/dovecot: dovecot 2.4 compat ``                             |
| [`84ebca08`](https://github.com/NixOS/nixpkgs/commit/84ebca080acacbacb6723e875b87d992547012d3) | `` radarr: 6.1.1.10360 -> 6.2.1.10461 ``                                                       |
| [`b14214ae`](https://github.com/NixOS/nixpkgs/commit/b14214ae2cf04aea3d59c95b48d1a194ca680b65) | `` google-cloud-sql-proxy: 2.21.1 -> 2.22.1 ``                                                 |
| [`b55fad69`](https://github.com/NixOS/nixpkgs/commit/b55fad695e03f146f89fc7c200e70ccf5b13933a) | `` python3Packages.openslide: 1.4.3 -> 1.4.6 ``                                                |
| [`87a4e2c0`](https://github.com/NixOS/nixpkgs/commit/87a4e2c0fb218bcf2358f370bfd1bb0659a888fb) | `` amnezia-vpn-bin: 4.8.16.0 -> 4.8.18.0 ``                                                    |
| [`081d077c`](https://github.com/NixOS/nixpkgs/commit/081d077cc53722a444f005cc595e7f8472059bd7) | `` rs-reticulum: remote `meta.mainProgram`, fix `versionCheckHook` ``                          |
| [`ff5976f9`](https://github.com/NixOS/nixpkgs/commit/ff5976f9ff7b11b083c8bf4a6bcb42a2291913bb) | `` rs-reticulum: 1.0.0 -> 1.0.1 ``                                                             |
| [`143dd2e5`](https://github.com/NixOS/nixpkgs/commit/143dd2e587f0ff3ec29c467f9f5f9891d1067062) | `` linux/common-config: adjust preempt settings to avoid conflicts ``                          |
| [`09476e6b`](https://github.com/NixOS/nixpkgs/commit/09476e6bdd0d7327d7b41e683a3ee7520ce05346) | `` linux/generate-config: disallow conflicting answers on choice questions ``                  |
| [`0f33c86e`](https://github.com/NixOS/nixpkgs/commit/0f33c86ea293a315d0d89b2c2a26996981b2d0da) | `` run0-sudo-shim: adopt by kuflierl; adopt by grimmauld ``                                    |
| [`f80687b8`](https://github.com/NixOS/nixpkgs/commit/f80687b86b737fc18f7260c238626985ba746faa) | `` run0-sudo-shim: init at 1.3.1 ``                                                            |
| [`5e44f837`](https://github.com/NixOS/nixpkgs/commit/5e44f8373db4b9bbe7cca2ee8719f2228887abab) | `` multica-cli: 0.3.16 -> 0.3.21 ``                                                            |
| [`8b77f938`](https://github.com/NixOS/nixpkgs/commit/8b77f9383503253746e46b4083fc222718ce52ed) | `` itgmaniaPackages.digital-dance: 1.1.3-unstable-2026-06-04 -> 1.1.3-unstable-2026-06-12 ``   |
| [`a5a9df5a`](https://github.com/NixOS/nixpkgs/commit/a5a9df5aa851acc5d522577bbcec034d310f9cf0) | `` itgmaniaPackages.itg3encore: 0-unstable-2026-06-05 -> 0-unstable-2026-06-13 ``              |
| [`56acb336`](https://github.com/NixOS/nixpkgs/commit/56acb33646b087366f2f8407a2d559c7b9a7a96b) | `` sbb-tui: 1.14.2 -> 1.15.0 ``                                                                |
| [`4abaf64d`](https://github.com/NixOS/nixpkgs/commit/4abaf64df2de93c1e03a8926f142c45dc67742e9) | `` trilium-server: Update homepage URL ``                                                      |
| [`e21ce66d`](https://github.com/NixOS/nixpkgs/commit/e21ce66d415270dd1e7c488e79fc97b2402abb2f) | `` treemd: 0.5.11 -> 0.5.12 ``                                                                 |
| [`3c2052ac`](https://github.com/NixOS/nixpkgs/commit/3c2052ac85fe196d2590c70657bf8d10e5367de9) | `` vimPlugins.codediff-nvim: 2.45.1 -> 2.49.2 ``                                               |
| [`d8a9a3d5`](https://github.com/NixOS/nixpkgs/commit/d8a9a3d5cbb3ac3010ad2e9cebbae0606af79f59) | `` bsky-cli: 0.0.79 -> 0.0.81 ``                                                               |
| [`086bc16b`](https://github.com/NixOS/nixpkgs/commit/086bc16bbf8da4e935d005b5fc1e47aeb8fe2079) | `` jfrog-cli: 2.107.0 -> 2.108.0 ``                                                            |
| [`5f4d2c23`](https://github.com/NixOS/nixpkgs/commit/5f4d2c23ca8d3732d0b6af9067c31db02610cf3a) | `` hygg: 0.1.20 -> 0.1.21 ``                                                                   |
| [`8522bee2`](https://github.com/NixOS/nixpkgs/commit/8522bee21abf29828a8b5cc92f3d3fe5bfcd1c3a) | `` scaphandre: drop ``                                                                         |
| [`2b23cc5d`](https://github.com/NixOS/nixpkgs/commit/2b23cc5dd1c468601d0adc37d90c8db907cf247d) | `` mqtt-exporter: relax promethus-client constraint ``                                         |
| [`f401c3ab`](https://github.com/NixOS/nixpkgs/commit/f401c3abf2cb3b1b242675d224b83bf520f0ab47) | `` nixos/test/prometheus-exporter: run tests in nspawn ``                                      |
| [`e7324c03`](https://github.com/NixOS/nixpkgs/commit/e7324c03a408ec569bcab0e250495653bb78d510) | `` gdbgui: enable __structuredAttrs ``                                                         |
| [`e98de264`](https://github.com/NixOS/nixpkgs/commit/e98de2644669c7b6226cd419e03432c2c92a7963) | `` gdbgui: reorder ``                                                                          |
| [`6d28be34`](https://github.com/NixOS/nixpkgs/commit/6d28be340fa1767fc8ca7f394b8d36c44c5c11a0) | `` gdbgui: migrate to pyproject ``                                                             |
| [`386cc593`](https://github.com/NixOS/nixpkgs/commit/386cc593dae0d13a83e5a616a9c5456c49b9c86b) | `` inputplumber: 0.77.3 -> 0.77.5 ``                                                           |
| [`772f3230`](https://github.com/NixOS/nixpkgs/commit/772f3230d276af1c87a809c5cf06e6b49c8d8d17) | `` unigine-superposition: remove dependency on mailspring ``                                   |
| [`712ab844`](https://github.com/NixOS/nixpkgs/commit/712ab844bee9fdeae873125c9785ae4f2073e6d4) | `` gdbgui: use finalAttrs ``                                                                   |
| [`5efefac4`](https://github.com/NixOS/nixpkgs/commit/5efefac4ae41ece2653996d295b2635a522495b1) | `` dnsmasq: 2.92rel2 -> 2.93 ``                                                                |
| [`ab0dc4cb`](https://github.com/NixOS/nixpkgs/commit/ab0dc4cb6d619a1c4b97b982f3e4972dcc137f02) | `` kdePackages.karousel: 0.15 -> 0.17 ``                                                       |
| [`13db573f`](https://github.com/NixOS/nixpkgs/commit/13db573f359bed6ecff3c5a0bf3e586c30d0a3fb) | `` gscreenshot: remove setuptools dependency ``                                                |
| [`efcf0d02`](https://github.com/NixOS/nixpkgs/commit/efcf0d02aa877f5e68983f3ebaf9c9004a93410b) | `` jackett: 0.24.2021 -> 0.24.2066 ``                                                          |
| [`a79e88fc`](https://github.com/NixOS/nixpkgs/commit/a79e88fcd77e2433511fe9de0f3a0f02182a0a29) | `` prometheus-knot-exporter: 3.5.4 -> 3.5.5 ``                                                 |
| [`01cc6270`](https://github.com/NixOS/nixpkgs/commit/01cc62705498dbc479a6e5daf20ca70b6bbd3033) | `` python3Packages.libknot: 3.5.4 -> 3.5.5 ``                                                  |

*... and 1452 more commits (truncated)*